### PR TITLE
Support for removing workspaces

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -3,6 +3,7 @@ package com.coder.toolbox
 import com.coder.toolbox.browser.BrowserUtil
 import com.coder.toolbox.models.WorkspaceAndAgentStatus
 import com.coder.toolbox.sdk.CoderRestClient
+import com.coder.toolbox.sdk.ex.APIResponseException
 import com.coder.toolbox.sdk.v2.models.Workspace
 import com.coder.toolbox.sdk.v2.models.WorkspaceAgent
 import com.coder.toolbox.util.withPath
@@ -147,11 +148,11 @@ class CoderRemoteEnvironment(
                 )
             }
             if (shouldDelete) {
-                if (status.canStop()) {
-                    client.stopWorkspace(workspace)
+                try {
+                    client.removeWorkspace(workspace)
+                } catch (e: APIResponseException) {
+                    ui.showErrorInfoPopup(e)
                 }
-
-                client.removeWorkspace(workspace)
             }
         }
     }

--- a/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
@@ -9,6 +9,7 @@ import com.jetbrains.toolbox.api.core.ServiceLocator
 import com.jetbrains.toolbox.api.core.ui.color.StateColor
 import com.jetbrains.toolbox.api.remoteDev.states.CustomRemoteEnvironmentState
 import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateColorPalette
+import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateIcons
 import com.jetbrains.toolbox.api.remoteDev.states.StandardRemoteEnvironmentState
 
 /**
@@ -59,19 +60,17 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
      * "disconnected" regardless of the label we give that status.
      */
     fun toRemoteEnvironmentState(serviceLocator: ServiceLocator): CustomRemoteEnvironmentState {
-        val stateColor = getStateColor(serviceLocator)
         return CustomRemoteEnvironmentState(
             label,
-            stateColor,
+            getStateColor(serviceLocator),
             ready(), // reachable
             // TODO@JB: How does this work?  Would like a spinner for pending states.
-            null, // iconId
+            getStateIcon()
         )
     }
 
     private fun getStateColor(serviceLocator: ServiceLocator): StateColor {
         val colorPalette = serviceLocator.getService(EnvironmentStateColorPalette::class.java)
-
 
         return if (ready()) colorPalette.getColor(StandardRemoteEnvironmentState.Active)
         else if (canStart()) colorPalette.getColor(StandardRemoteEnvironmentState.Failed)
@@ -79,6 +78,14 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
         else if (this == DELETING) colorPalette.getColor(StandardRemoteEnvironmentState.Deleting)
         else if (this == DELETED) colorPalette.getColor(StandardRemoteEnvironmentState.Deleted)
         else colorPalette.getColor(StandardRemoteEnvironmentState.Unreachable)
+    }
+
+    private fun getStateIcon(): EnvironmentStateIcons {
+        return if (ready()) EnvironmentStateIcons.Active
+        else if (canStart()) EnvironmentStateIcons.Hibernated
+        else if (pending()) EnvironmentStateIcons.Connecting
+        else if (this == DELETING || this == DELETED) EnvironmentStateIcons.Offline
+        else EnvironmentStateIcons.NoIcon
     }
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
@@ -76,6 +76,8 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
         return if (ready()) colorPalette.getColor(StandardRemoteEnvironmentState.Active)
         else if (canStart()) colorPalette.getColor(StandardRemoteEnvironmentState.Failed)
         else if (pending()) colorPalette.getColor(StandardRemoteEnvironmentState.Activating)
+        else if (this == DELETING) colorPalette.getColor(StandardRemoteEnvironmentState.Deleting)
+        else if (this == DELETED) colorPalette.getColor(StandardRemoteEnvironmentState.Deleted)
         else colorPalette.getColor(StandardRemoteEnvironmentState.Unreachable)
     }
 

--- a/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
@@ -107,6 +107,11 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
     fun canStart(): Boolean = listOf(STOPPED, FAILED, CANCELED)
         .contains(this)
 
+    /**
+     * Return true if the workspace can be stopped.
+     */
+    fun canStop(): Boolean = ready() || pending()
+
     // We want to check that the workspace is `running`, the agent is
     // `connected`, and the agent lifecycle state is `ready` to ensure the best
     // possible scenario for attempting a connection.

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -240,10 +240,14 @@ open class CoderRestClient(
     }
 
     /**
-     * @throws [APIResponseException].
+     * @throws [APIResponseException] if issues are encountered during deletion
      */
     fun removeWorkspace(workspace: Workspace) {
-        // TODO - implement this
+        val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.DELETE, false)
+        val buildResponse = retroRestClient.createWorkspaceBuild(workspace.id, buildRequest).execute()
+        if (buildResponse.code() != HttpURLConnection.HTTP_CREATED) {
+            throw APIResponseException("delete workspace ${workspace.name}", url, buildResponse)
+        }
     }
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -30,7 +30,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.net.HttpURLConnection
 import java.net.ProxySelector
 import java.net.URL
-import java.util.*
+import java.util.UUID
 import javax.net.ssl.X509TrustManager
 
 /**
@@ -229,7 +229,6 @@ open class CoderRestClient(
     }
 
     /**
-     * @throws [APIResponseException].
      */
     fun stopWorkspace(workspace: Workspace): WorkspaceBuild {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.STOP)
@@ -238,6 +237,13 @@ open class CoderRestClient(
             throw APIResponseException("stop workspace ${workspace.name}", url, buildResponse)
         }
         return buildResponse.body()!!
+    }
+
+    /**
+     * @throws [APIResponseException].
+     */
+    fun removeWorkspace(workspace: Workspace) {
+        // TODO - implement this
     }
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/CreateWorkspaceBuildRequest.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/CreateWorkspaceBuildRequest.kt
@@ -20,12 +20,13 @@ data class CreateWorkspaceBuildRequest(
 
         if (templateVersionID != other.templateVersionID) return false
         if (transition != other.transition) return false
-
+        if (orphan != other.orphan) return false
         return true
     }
 
     override fun hashCode(): Int {
-        var result = templateVersionID?.hashCode() ?: 0
+        var result = orphan?.hashCode() ?: 0
+        result = 31 * result + (templateVersionID?.hashCode() ?: 0)
         result = 31 * result + transition.hashCode()
         return result
     }

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/CreateWorkspaceBuildRequest.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/CreateWorkspaceBuildRequest.kt
@@ -8,8 +8,9 @@ import java.util.UUID
 data class CreateWorkspaceBuildRequest(
     // Use to update the workspace to a new template version.
     @Json(name = "template_version_id") val templateVersionID: UUID?,
-    // Use to start and stop the workspace.
+    // Use to start, stop and delete the workspace.
     @Json(name = "transition") val transition: WorkspaceTransition,
+    @Json(name = "orphan") var orphan: Boolean? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
- facade for Coder's  REST endpoint to remove a workspace
- pop-up dailog for user to confirm the workspace removal
- add support for status icons and as a bonus Toolbox is now displaying nice animation around the header bar when workspace is starting or stopping
- resolves #7 

Small note: info and error dialogs created with ToolboxUi#showInfoPopup, ToolboxUi#showYesNoPopup, and ToolboxUi#showOkCancelPopup only appear on the main page where all environments are listed.  JetBrains is addressing the issue but until then user can interact with the confirmation dialog only from the front page.