### PR TITLE
fix: release notes formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,12 +69,9 @@ jobs:
           VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
           NAME="$(echo "$PROPERTIES" | grep "^group:" | cut -f2- -d ' ')"
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" > RELEASE_NOTES.md
 
       # Run plugin build
       - name: Run Build
@@ -124,7 +121,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ needs.build.outputs.changelog }}" > RELEASE_NOTES.md
           gh release create v${{ needs.build.outputs.version }} \
             --draft \
             --target ${GITHUB_REF_NAME} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,13 +116,19 @@ jobs:
             --jq '.[] | select(.draft == true) | .id' \
             | xargs -I '{}' gh api -X DELETE repos/${{ github.repository }}/releases/{}
 
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts/
+
       # Create new release draft - which is not publicly visible and requires manual acceptance
       - name: Create Release Draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create v${{ needs.build.outputs.version }} \
-            --draft \
+            --draft artifacts/* \
             --target ${GITHUB_REF_NAME} \
             --title "v${{ needs.build.outputs.version }}" \
             --notes-file RELEASE_NOTES.md


### PR DESCRIPTION
- gh cli (gh release create) does not need \n and \r to be encoded as it should correctly interpret raw newlines from files.
- also  make zip available to download from draft release as it is easier to find