### PR TITLE
fix: Change token input field to Password type

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/views/TokenPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/TokenPage.kt
@@ -25,7 +25,7 @@ class TokenPage(
     token: Pair<String, Source>?,
     private val onToken: ((token: String) -> Unit),
 ) : CoderPage(context, context.i18n.ptrl("Enter your token")) {
-    private val tokenField = TextField(context.i18n.ptrl("Token"), token?.first ?: "", TextType.General)
+    private val tokenField = TextField(context.i18n.ptrl("Token"), token?.first ?: "", TextType.Password)
 
     /**
      * Fields for this page, displayed in order.


### PR DESCRIPTION
## Summary
- Changes token text field type from General to Password to hide sensitive token values

## Test plan
- Install the plugin and verify token input is masked
<img width="446" alt="Screenshot 2025-03-11 at 04 20 38" src="https://github.com/user-attachments/assets/43dae367-a456-4d0f-b9a1-17079b98346c" />


Resolves #3

📱 Generated with [Claude Code](https://claude.ai/code)