### PR TITLE
Impl: icons with support for light&dark themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 - initial support for JetBrains Toolbox 2.6.0.38311 with the possibility to manage the workspaces - i.e. start, stop,
   update and delete actions and also quick shortcuts to templates, web terminal and dashboard.
+- support for light & dark themes

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -78,7 +78,7 @@ class CoderRemoteEnvironment(
             workspace = workspace.copy(latestBuild = build)
             update(workspace, agent)
         },
-        Action(context.i18n.ptrl("Update"), enabled = { workspace.outdated }) {
+        Action(context.i18n.ptrl("Update and start"), enabled = { workspace.outdated }) {
             val build = client.updateWorkspace(workspace)
             workspace = workspace.copy(latestBuild = build)
             update(workspace, agent)

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -69,25 +69,33 @@ class CoderRemoteEnvironment(
                     }
                 }
             })
-        if (wsRawStatus.canStart() && !workspace.outdated) {
-            actions.add(Action(context.i18n.ptrl("Start")) {
-                val build = client.startWorkspace(workspace)
-                update(workspace.copy(latestBuild = build), agent)
-            })
+
+        if (wsRawStatus.canStart()) {
+            if (workspace.outdated) {
+                actions.add(Action(context.i18n.ptrl("Update and start")) {
+                    val build = client.updateWorkspace(workspace)
+                    update(workspace.copy(latestBuild = build), agent)
+                })
+            } else {
+                actions.add(Action(context.i18n.ptrl("Start")) {
+                    val build = client.startWorkspace(workspace)
+                    update(workspace.copy(latestBuild = build), agent)
+                })
+            }
         }
         if (wsRawStatus.canStop()) {
-            actions.add(Action(context.i18n.ptrl("Stop")) {
-                val build = client.stopWorkspace(workspace)
-                update(workspace.copy(latestBuild = build), agent)
-            })
+            if (workspace.outdated) {
+                actions.add(Action(context.i18n.ptrl("Update and restart")) {
+                    val build = client.updateWorkspace(workspace)
+                    update(workspace.copy(latestBuild = build), agent)
+                })
+            } else {
+                actions.add(Action(context.i18n.ptrl("Stop")) {
+                    val build = client.stopWorkspace(workspace)
+                    update(workspace.copy(latestBuild = build), agent)
+                })
+            }
         }
-        if (workspace.outdated) {
-            actions.add(Action(context.i18n.ptrl("Update and start")) {
-                val build = client.updateWorkspace(workspace)
-                update(workspace.copy(latestBuild = build), agent)
-            })
-        }
-
         return actions
     }
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -68,7 +68,7 @@ class CoderRemoteEnvironment(
                 }
             }
         },
-        Action(context.i18n.ptrl("Start"), enabled = { wsRawStatus.canStart() }) {
+        Action(context.i18n.ptrl("Start"), enabled = { wsRawStatus.canStart() && !workspace.outdated }) {
             val build = client.startWorkspace(workspace)
             workspace = workspace.copy(latestBuild = build)
             update(workspace, agent)

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -72,22 +72,19 @@ class CoderRemoteEnvironment(
         if (wsRawStatus.canStart() && !workspace.outdated) {
             actions.add(Action(context.i18n.ptrl("Start")) {
                 val build = client.startWorkspace(workspace)
-                workspace = workspace.copy(latestBuild = build)
-                update(workspace, agent)
+                update(workspace.copy(latestBuild = build), agent)
             })
         }
         if (wsRawStatus.canStop()) {
             actions.add(Action(context.i18n.ptrl("Stop")) {
                 val build = client.stopWorkspace(workspace)
-                workspace = workspace.copy(latestBuild = build)
-                update(workspace, agent)
+                update(workspace.copy(latestBuild = build), agent)
             })
         }
         if (workspace.outdated) {
             actions.add(Action(context.i18n.ptrl("Update and start")) {
                 val build = client.updateWorkspace(workspace)
-                workspace = workspace.copy(latestBuild = build)
-                update(workspace, agent)
+                update(workspace.copy(latestBuild = build), agent)
             })
         }
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -17,6 +17,7 @@ import com.coder.toolbox.views.NewEnvironmentPage
 import com.coder.toolbox.views.SignInPage
 import com.coder.toolbox.views.TokenPage
 import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon
+import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon.IconType
 import com.jetbrains.toolbox.api.core.util.LoadableState
 import com.jetbrains.toolbox.api.remoteDev.ProviderVisibilityState
 import com.jetbrains.toolbox.api.remoteDev.RemoteProvider
@@ -181,10 +182,16 @@ class CoderRemoteProvider(
     }
 
     override val svgIcon: SvgIcon =
-        SvgIcon(this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf())
+        SvgIcon(
+            this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf(),
+            type = IconType.Masked
+        )
 
     override val noEnvironmentsSvgIcon: SvgIcon? =
-        SvgIcon(this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf())
+        SvgIcon(
+            this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf(),
+            type = IconType.Masked
+        )
 
     /**
      * TODO@JB: It would be nice to show "loading workspaces" at first but it

--- a/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
@@ -2,6 +2,7 @@ package com.coder.toolbox.views
 
 import com.coder.toolbox.CoderToolboxContext
 import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon
+import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon.IconType
 import com.jetbrains.toolbox.api.localization.LocalizableString
 import com.jetbrains.toolbox.api.ui.actions.RunnableActionDescription
 import com.jetbrains.toolbox.api.ui.components.UiField
@@ -46,9 +47,12 @@ abstract class CoderPage(
      * This seems to only work on the first page.
      */
     override val svgIcon: SvgIcon? = if (showIcon) {
-        SvgIcon(this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf())
+        SvgIcon(
+            this::class.java.getResourceAsStream("/icon.svg")?.readAllBytes() ?: byteArrayOf(),
+            type = IconType.Masked
+        )
     } else {
-        SvgIcon(byteArrayOf())
+        SvgIcon(byteArrayOf(), type = IconType.Masked)
     }
 
     /**

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-msgid "Update"
+msgid "Update and start"
 msgstr ""
 
 msgid "Settings"

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -76,6 +76,9 @@ msgstr ""
 msgid "Update and start"
 msgstr ""
 
+msgid "Update and restart"
+msgstr ""
+
 msgid "Settings"
 msgstr ""
 


### PR DESCRIPTION
- LAF support in Toolbox is quite primitive, it turns out icon support for light and dark themes is enabled by a masked flag on the icons.
- the mask flag controls whether the svg colors are inverted in light&dark themes.

Among other things we also fixed and issue with the `Start` button which remained active when a workspace was stopped and outdated. In order to be more consistent with the web client we renamed the button to `Update and start` to reflect that it also starts the workspace.

Running and outdated workspaces also received a new action button: `Update and restart`.

- resolves #31
![image](https://github.com/user-attachments/assets/f54a71f4-ca8d-4655-b5ff-e95c52e3ad9a)
![image](https://github.com/user-attachments/assets/a81901ac-b7fe-482d-bf09-13baaa02455b)

