### PR TITLE
fix: fix vendor name and repo url.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,8 +75,8 @@ val extension = ExtensionJson(
     meta = ExtensionJsonMeta(
         name = "Coder",
         description = "Connects your JetBrains IDE to Coder workspaces",
-        vendor = "Coder",
-        url = "https://github.com/coder/coder-jetbrains-toolbox-plugin",
+        vendor = "Coder Technologies, Inc.",
+        url = "https://github.com/coder/coder-jetbrains-toolbox",
     )
 )
 


### PR DESCRIPTION
We use the Vendor name [Coder Technologies, Inc.](https://plugins.jetbrains.com/vendor/coder)