### PR TITLE
fix: socket connection timeout

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
@@ -15,7 +15,6 @@ import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateColorPalette
 import com.jetbrains.toolbox.api.remoteDev.ui.EnvironmentUiPageManager
 import com.jetbrains.toolbox.api.ui.ToolboxUi
 import kotlinx.coroutines.CoroutineScope
-import okhttp3.OkHttpClient
 
 /**
  * Entry point into the extension.
@@ -35,8 +34,7 @@ class CoderToolboxExtension : RemoteDevExtension {
                 serviceLocator.getService(LocalizableStringFactory::class.java),
                 CoderSettingsStore(serviceLocator.getService(PluginSettingsStore::class.java), Environment(), logger),
                 CoderSecretsStore(serviceLocator.getService(PluginSecretStore::class.java)),
-            ),
-            OkHttpClient(),
+            )
         )
     }
 }

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -103,6 +103,7 @@ open class CoderRestClient(
             builder
                 .sslSocketFactory(socketFactory, trustManagers[0] as X509TrustManager)
                 .hostnameVerifier(CoderHostnameVerifier(settings.tls.altHostname))
+                .retryOnConnectionFailure(true)
                 .addInterceptor {
                     it.proceed(
                         it.request().newBuilder().addHeader(

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -53,16 +53,19 @@ open class CoderRestClient(
     val token: String?,
     private val proxyValues: ProxyValues? = null,
     private val pluginVersion: String = "development",
-    existingHttpClient: OkHttpClient? = null,
 ) {
     private val settings = context.settingsStore.readOnly()
-    private val httpClient: OkHttpClient
-    private val retroRestClient: CoderV2RestFacade
+    private lateinit var httpClient: OkHttpClient
+    private lateinit var retroRestClient: CoderV2RestFacade
 
     lateinit var me: User
     lateinit var buildVersion: String
 
     init {
+        setupSession()
+    }
+
+    fun setupSession() {
         val moshi =
             Moshi.Builder()
                 .add(ArchConverter())
@@ -73,7 +76,7 @@ open class CoderRestClient(
 
         val socketFactory = coderSocketFactory(settings.tls)
         val trustManagers = coderTrustManagers(settings.tls.caPath)
-        var builder = existingHttpClient?.newBuilder() ?: OkHttpClient.Builder()
+        var builder = OkHttpClient.Builder()
 
         if (proxyValues != null) {
             builder =

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.withTimeout
-import okhttp3.OkHttpClient
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
@@ -26,7 +25,6 @@ import kotlin.time.toJavaDuration
 
 open class CoderProtocolHandler(
     private val context: CoderToolboxContext,
-    private val httpClient: OkHttpClient?,
     private val dialogUi: DialogUi,
     private val isInitialized: StateFlow<Boolean>,
 ) {
@@ -230,8 +228,7 @@ open class CoderProtocolHandler(
             deploymentURL.toURL(),
             token,
             proxyValues = null, // TODO - not sure the above comment applies as we are creating our own http client
-            PluginManager.pluginInfo.version,
-            httpClient
+            PluginManager.pluginInfo.version
         )
         client.authenticate()
         return client

--- a/src/main/kotlin/com/coder/toolbox/views/ConnectPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/ConnectPage.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import okhttp3.OkHttpClient
 import java.net.URL
 
 /**
@@ -24,7 +23,6 @@ class ConnectPage(
     private val context: CoderToolboxContext,
     private val url: URL,
     private val token: String?,
-    private val httpClient: OkHttpClient,
     private val onCancel: () -> Unit,
     private val onConnect: (
         client: CoderRestClient,
@@ -95,7 +93,6 @@ class ConnectPage(
                     token,
                     proxyValues = null,
                     PluginManager.pluginInfo.version,
-                    httpClient
                 )
                 client.authenticate()
                 updateStatus(context.i18n.ptrl("Checking Coder binary..."), error = null)


### PR DESCRIPTION
Context:
- okhttp uses an HTTP/2 connection to the coder rest api in order to resolves the workspaces.
- HTTP/2 uses a single TCP connection for multiple requests (multiplexing). If the connection is idle, the http server can close that connection, with client side ending in a socket timeout if it doesn't detect the drop in time.
- similarly on the client side, if the OS goes into sleep mode, the connection might have been interrupted. HTTP/2 doesn't always detect this quickly, leading to stale streams when Toolbox wakes up.

Implementation:

- we could try to force the client to use HTTP/1 which creates a TCP connection for each request, but from my testing it seems that configuring a retry strategy when a client attempts to reuse a TCP connection that has unexpectedly closed  plus detecting large gaps between the last poll time and socket timeout time  allows us to reset the client and create fresh TCP connections.

- resolves #13