### PR TITLE
fix: use correct vendor id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ val extension = ExtensionJson(
     meta = ExtensionJsonMeta(
         name = "Coder",
         description = "Connects your JetBrains IDE to Coder workspaces",
-        vendor = "Coder Technologies, Inc.",
+        vendor = "coder",
         url = "https://github.com/coder/coder-jetbrains-toolbox",
     )
 )


### PR DESCRIPTION
We need to use the correct vendor ID: https://plugins.jetbrains.com/vendor/coder