### PR TITLE
build: update publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+        run: |
+          ./gradlew clean pluginZip --info
+          gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
       # Create pull request
       - name: Create Pull Request


### PR DESCRIPTION
- initial publish was done manually
- but we still want a gh release so we have to augment the release workflow to build the zip file because the publish task does not run