### PR TITLE
fix: improve ssh config logic when workspaces change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- SSH config is regenerated correctly when Workspaces are added or removed
+
 ## 0.1.0 - 2025-04-01
 
 ### Added

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -194,10 +194,9 @@ class CoderRemoteEnvironment(
      */
     override fun equals(other: Any?): Boolean {
         if (other == null) return false
-        if (this === other) return true // Note the triple ===
+        if (this === other) return true
         if (other !is CoderRemoteEnvironment) return false
-        if (id != other.id) return false
-        return true
+        return id == other.id
     }
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -113,12 +113,11 @@ class CoderRemoteProvider(
                     return@launch
                 }
 
-                // Reconfigure if a new environment is found.
-                // TODO@JB: Should we use the add/remove listeners instead?
-                val newEnvironments = resolvedEnvironments.subtract(lastEnvironments)
-                if (newEnvironments.isNotEmpty()) {
-                    context.logger.info("Found new environment(s), reconfiguring CLI: $newEnvironments")
-                    cli.configSsh(newEnvironments.map { it.name }.toSet())
+
+                // Reconfigure if environments changed.
+                if (lastEnvironments.size != resolvedEnvironments.size || lastEnvironments != resolvedEnvironments) {
+                    context.logger.info("Workspaces have changed, reconfiguring CLI: $resolvedEnvironments")
+                    cli.configSsh(resolvedEnvironments.map { it.name }.toSet())
                 }
 
                 environments.update {


### PR DESCRIPTION
- previously, ssh reconfiguration was triggered only when new workspaces were added, and
  the ssh config was generated only with the additional environments removing the configuration
  for the previous ones. This means that when a new workspace is created from the web dashboard,
  the old workspaces are no longer accessible via ssh from Toolbox
- now, the logic ensures ssh reconfiguration happens whenever the set of environments changes
  (including additions or removals), making it more robust, and configuration happens for all
  valid workspaces.

- resolves #14