### PR TITLE
fix: override default delete confirmation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - SSH config is regenerated correctly when Workspaces are added or removed
+- only one confirmation dialog is shown when removing a Workspace
 
 ## 0.1.0 - 2025-04-01
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -9,6 +9,7 @@ import com.coder.toolbox.sdk.v2.models.WorkspaceAgent
 import com.coder.toolbox.util.withPath
 import com.coder.toolbox.views.Action
 import com.coder.toolbox.views.EnvironmentView
+import com.jetbrains.toolbox.api.remoteDev.DeleteEnvironmentConfirmationParams
 import com.jetbrains.toolbox.api.remoteDev.EnvironmentVisibilityState
 import com.jetbrains.toolbox.api.remoteDev.RemoteProviderEnvironment
 import com.jetbrains.toolbox.api.remoteDev.environments.EnvironmentContentsView
@@ -149,42 +150,36 @@ class CoderRemoteEnvironment(
         }
     }
 
+    override fun getDeleteEnvironmentConfirmationParams(): DeleteEnvironmentConfirmationParams? {
+        return object : DeleteEnvironmentConfirmationParams {
+            override val cancelButtonText: String = "Cancel"
+            override val confirmButtonText: String = "Delete"
+            override val message: String =
+                if (wsRawStatus.canStop()) "Workspace will be closed and all the information will be lost, including all files, unsaved changes, historical info and usage data."
+                else "All the information in this workspace will be lost, including all files, unsaved changes, historical info and usage data."
+            override val title: String = if (wsRawStatus.canStop()) "Delete running workspace?" else "Delete workspace?"
+        }
+    }
+
     override fun onDelete() {
         context.cs.launch {
-            val shouldDelete = if (wsRawStatus.canStop()) {
-                context.ui.showOkCancelPopup(
-                    context.i18n.ptrl("Delete running workspace?"),
-                    context.i18n.ptrl("Workspace will be closed and all the information in this workspace will be lost, including all files, unsaved changes and historical."),
-                    context.i18n.ptrl("Delete"),
-                    context.i18n.ptrl("Cancel")
-                )
-            } else {
-                context.ui.showOkCancelPopup(
-                    context.i18n.ptrl("Delete workspace?"),
-                    context.i18n.ptrl("All the information in this workspace will be lost, including all files, unsaved changes and historical."),
-                    context.i18n.ptrl("Delete"),
-                    context.i18n.ptrl("Cancel")
-                )
-            }
-            if (shouldDelete) {
-                try {
-                    client.removeWorkspace(workspace)
-                    context.cs.launch {
-                        withTimeout(5.minutes) {
-                            var workspaceStillExists = true
-                            while (context.cs.isActive && workspaceStillExists) {
-                                if (wsRawStatus == WorkspaceAndAgentStatus.DELETING || wsRawStatus == WorkspaceAndAgentStatus.DELETED) {
-                                    workspaceStillExists = false
-                                    context.envPageManager.showPluginEnvironmentsPage()
-                                } else {
-                                    delay(1.seconds)
-                                }
+            try {
+                client.removeWorkspace(workspace)
+                context.cs.launch {
+                    withTimeout(5.minutes) {
+                        var workspaceStillExists = true
+                        while (context.cs.isActive && workspaceStillExists) {
+                            if (wsRawStatus == WorkspaceAndAgentStatus.DELETING || wsRawStatus == WorkspaceAndAgentStatus.DELETED) {
+                                workspaceStillExists = false
+                                context.envPageManager.showPluginEnvironmentsPage()
+                            } else {
+                                delay(1.seconds)
                             }
                         }
                     }
-                } catch (e: APIResponseException) {
-                    context.ui.showErrorInfoPopup(e)
                 }
+            } catch (e: APIResponseException) {
+                context.ui.showErrorInfoPopup(e)
             }
         }
     }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -165,6 +165,12 @@ class CoderRemoteEnvironment(
         context.cs.launch {
             try {
                 client.removeWorkspace(workspace)
+                // mark the env as deleting otherwise we will have to
+                // wait for the poller to update the status in the next 5 seconds
+                state.update {
+                    WorkspaceAndAgentStatus.DELETING.toRemoteEnvironmentState(context)
+                }
+
                 context.cs.launch {
                     withTimeout(5.minutes) {
                         var workspaceStillExists = true

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -131,7 +131,7 @@ class CoderRemoteProvider(
                 }
                 lastEnvironments.apply {
                     clear()
-                    addAll(resolvedEnvironments)
+                    addAll(resolvedEnvironments.sortedBy { it.id })
                 }
             } catch (_: CancellationException) {
                 context.logger.debug("${client.url} polling loop canceled")

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -28,22 +28,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-msgid "Delete"
-msgstr ""
-
 msgid "Cancel"
-msgstr ""
-
-msgid "Delete running workspace?"
-msgstr ""
-
-msgid "Delete workspace?"
-msgstr ""
-
-msgid "Workspace will be closed and all the information in this workspace will be lost, including all files, unsaved changes and historical."
-msgstr ""
-
-msgid "All the information in this workspace will be lost, including all files, unsaved changes and historical."
 msgstr ""
 
 msgid "Session Token"


### PR DESCRIPTION
- right now there are two confirmation dialogs when removing a workspace from Toolbox
- with this patch we force Toolbox to discard its default dialog and show a custom one with
  the Coder titles and messages.

- resolves #60