### PR TITLE
fix: redirect user to the login screen after log out from a deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- after log out, user is redirected back to the initial log in screen 
+
 ## 0.1.1 - 2025-04-03
 
 ### Fixed

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -187,7 +187,10 @@ class CoderRemoteProvider(
     override fun getAccountDropDown(): DropDownMenu? {
         val username = client?.me?.username
         if (username != null) {
-            return dropDownFactory(context.i18n.pnotr(username), { logout() })
+            return dropDownFactory(context.i18n.pnotr(username)) {
+                logout()
+                context.ui.showUiPage(getOverrideUiPage()!!)
+            }
         }
         return null
     }
@@ -211,6 +214,7 @@ class CoderRemoteProvider(
         lastEnvironments.clear()
         environments.value = LoadableState.Value(emptyList())
         isInitialized.update { false }
+        client = null
     }
 
     override val svgIcon: SvgIcon =


### PR DESCRIPTION
- up until now after users hits the drop-down log out action he was presented with a blank page and had to restart Toolbox in order to reach out to the login screen.

- resolves #34