### PR TITLE
fix: url refresh after log out and log in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- after log out, user is redirected back to the initial log in screen 
+- after log out, user is redirected back to the initial log in screen
+- url on the main page is now refreshed when switching between multiple deployments (via logout/login or URI handling)
 
 ## 0.1.1 - 2025-04-03
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -177,7 +177,7 @@ class CoderRemoteEnvironment(
                         while (context.cs.isActive && workspaceStillExists) {
                             if (wsRawStatus == WorkspaceAndAgentStatus.DELETING || wsRawStatus == WorkspaceAndAgentStatus.DELETED) {
                                 workspaceStillExists = false
-                                context.envPageManager.showPluginEnvironmentsPage()
+                                context.envPageManager.showPluginEnvironmentsPage(true)
                             } else {
                                 delay(1.seconds)
                             }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -177,7 +177,7 @@ class CoderRemoteEnvironment(
                         while (context.cs.isActive && workspaceStillExists) {
                             if (wsRawStatus == WorkspaceAndAgentStatus.DELETING || wsRawStatus == WorkspaceAndAgentStatus.DELETED) {
                                 workspaceStillExists = false
-                                context.envPageManager.showPluginEnvironmentsPage(true)
+                                context.envPageManager.showMainPageWithUrlVisible()
                             } else {
                                 delay(1.seconds)
                             }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -67,7 +67,8 @@ class CoderRemoteProvider(
     // On the first load, automatically log in if we can.
     private var firstRun = true
     private val isInitialized: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    private var coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(getDeploymentURL()?.first ?: ""))
+    private var coderHeaderPage =
+        NewEnvironmentPage(context, context.i18n.pnotr("Coder"), getDeploymentURL()?.first ?: "")
     private val linkHandler = CoderProtocolHandler(context, dialogUi, isInitialized)
     override val environments: MutableStateFlow<LoadableState<List<RemoteProviderEnvironment>>> = MutableStateFlow(
         LoadableState.Value(emptyList())
@@ -243,7 +244,7 @@ class CoderRemoteProvider(
      *          this changes it would be nice to have a new spot to show the
      *          URL.
      */
-    override val canCreateNewEnvironments: Boolean = false
+    override val canCreateNewEnvironments: Boolean = true
 
     /**
      * Just displays the deployment URL at the moment, but we could use this as
@@ -273,7 +274,7 @@ class CoderRemoteProvider(
             close()
             // start initialization with the new settings
             this@CoderRemoteProvider.client = restClient
-            coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(restClient.url.toString()))
+            coderHeaderPage.refreshUrl(restClient.url.toString())
             pollJob = poll(restClient, cli)
         }
     }
@@ -287,7 +288,7 @@ class CoderRemoteProvider(
      * than using multiple root pages.
      */
     private fun goToEnvironmentsPage() {
-        context.envPageManager.showPluginEnvironmentsPage()
+        context.envPageManager.showPluginEnvironmentsPage(true)
     }
 
     /**
@@ -359,6 +360,7 @@ class CoderRemoteProvider(
         pollError = null
         pollJob?.cancel()
         pollJob = poll(client, cli)
+        coderHeaderPage.refreshUrl(getDeploymentURL()?.first ?: "")
         goToEnvironmentsPage()
     }
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -288,7 +288,7 @@ class CoderRemoteProvider(
      * than using multiple root pages.
      */
     private fun goToEnvironmentsPage() {
-        context.envPageManager.showPluginEnvironmentsPage(true)
+        context.envPageManager.showMainPageWithUrlVisible()
     }
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/EnvironmentUiPageManagerExtensions.kt
+++ b/src/main/kotlin/com/coder/toolbox/EnvironmentUiPageManagerExtensions.kt
@@ -1,0 +1,7 @@
+package com.coder.toolbox
+
+import com.jetbrains.toolbox.api.remoteDev.ui.EnvironmentUiPageManager
+
+fun EnvironmentUiPageManager.showMainPageWithUrlVisible() {
+    showPluginEnvironmentsPage(true)
+}

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -9,6 +9,7 @@ import com.coder.toolbox.sdk.CoderRestClient
 import com.coder.toolbox.sdk.v2.models.Workspace
 import com.coder.toolbox.sdk.v2.models.WorkspaceAgent
 import com.coder.toolbox.sdk.v2.models.WorkspaceStatus
+import com.coder.toolbox.showMainPageWithUrlVisible
 import com.jetbrains.toolbox.api.localization.LocalizableString
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
@@ -322,7 +323,7 @@ private suspend fun CoderToolboxContext.showInfoPopup(
 
 private fun CoderToolboxContext.popupPluginMainPage() {
     this.ui.showWindow()
-    this.envPageManager.showPluginEnvironmentsPage(true)
+    this.envPageManager.showMainPageWithUrlVisible()
 }
 
 /**

--- a/src/main/kotlin/com/coder/toolbox/views/NewEnvironmentPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/NewEnvironmentPage.kt
@@ -2,9 +2,10 @@ package com.coder.toolbox.views
 
 import com.coder.toolbox.CoderToolboxContext
 import com.jetbrains.toolbox.api.localization.LocalizableString
+import com.jetbrains.toolbox.api.ui.components.LinkField
 import com.jetbrains.toolbox.api.ui.components.UiField
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
 
 /**
@@ -14,7 +15,14 @@ import kotlinx.coroutines.flow.StateFlow
  * For now we just use this to display the deployment URL since we do not
  * support creating environments from the plugin.
  */
-class NewEnvironmentPage(context: CoderToolboxContext, deploymentURL: LocalizableString) :
-    CoderPage(context, deploymentURL) {
-    override val fields: StateFlow<List<UiField>> = MutableStateFlow(emptyList())
+class NewEnvironmentPage(private val context: CoderToolboxContext, title: LocalizableString, initialUrl: String) :
+    CoderPage(context, title) {
+    override val fields: MutableStateFlow<List<UiField>> =
+        MutableStateFlow(listOf(LinkField(context.i18n.pnotr(initialUrl), initialUrl)))
+
+    fun refreshUrl(url: String) {
+        fields.update {
+            listOf(LinkField(context.i18n.pnotr(url), url))
+        }
+    }
 }


### PR DESCRIPTION
- the main env header page API is quite limiting, in the sense that the title is never allowed to change. Today we display the Coder URL as the title. However, if the user switches between two deployments via log out and then log in, the URL is never refreshed, leading to a confusing UI (URL is old, while workspaces are from the new deployment)
- to workaround the issue we redesigned the page, to have a static string as the page, and bellow the first row, have a link field reflecting the new URL.

 - resolves #66