### PR TITLE
fix: ssh connection to a workspace is established only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- SSH connection to a Workspace is no longer established only once 
+
 ### Changed
 
 - action buttons on the token input step were swapped to achieve better keyboard navigation 


### PR DESCRIPTION
- right now ssh automatically connects to the workspace when a user selects it from the main env. page. However, if the user manually disconnects from the hamburger menu, the SSH is no longer automatically established afterward.
- the reason for this behavior was that the connection request flag that triggered the ssh connection behind the scenes was never reset. In order to reset we have to know when a user hits the disconnect button.
- fortunately Toolbox provides two callbacks, one before establishing the ssh connection and another one right after disconnect. Even though we don't know the reason for disconnect it's still a good opportunity to reset the request flag.

- resolves #38