### PR TITLE
fix: go to previous step when connection fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - action buttons on the token input step were swapped to achieve better keyboard navigation 
 
+### Fixed
+
+- authorization wizard automatically goes to a previous screen when an error is encountered during connection to Coder deployment 
+
 ## 0.1.3 - 2025-04-09
 
 ### Fixed

--- a/src/main/kotlin/com/coder/toolbox/views/AuthWizardPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/AuthWizardPage.kt
@@ -22,7 +22,7 @@ class AuthWizardPage(
 
     private val signInStep = SignInStep(context)
     private val tokenStep = TokenStep(context)
-    private val connectStep = ConnectStep(context, shouldAutoLogin, this::notify, onConnect)
+    private val connectStep = ConnectStep(context, shouldAutoLogin, this::notify, this::displaySteps, onConnect)
 
 
     /**

--- a/src/main/kotlin/com/coder/toolbox/views/ConnectStep.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/ConnectStep.kt
@@ -27,6 +27,7 @@ class ConnectStep(
     private val context: CoderToolboxContext,
     private val shouldAutoLogin: StateFlow<Boolean>,
     private val notify: (String, Throwable) -> Unit,
+    private val refreshWizard: () -> Unit,
     private val onConnect: (
         client: CoderRestClient,
         cli: CoderCLIManager,
@@ -102,9 +103,13 @@ class ConnectStep(
             } catch (ex: CancellationException) {
                 if (ex.message != USER_HIT_THE_BACK_BUTTON) {
                     notify("Connection to ${url.host} was configured", ex)
+                    onBack()
+                    refreshWizard()
                 }
             } catch (ex: Exception) {
                 notify("Failed to configure ${url.host}", ex)
+                onBack()
+                refreshWizard()
             }
         }
     }


### PR DESCRIPTION
- happens when an error is encountered during connection (like exceptions caused by an expired token)
- right now the auth wizard stays on the last step.
- with this changeset the auth steps reset to the initial sign in for auto-connect, or it goes back one step back to the token input step for manual authentication