### PR TITLE
fix: show loading indicator instead of "No workspaces yet" (#44)

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -68,7 +68,7 @@ class CoderRemoteProvider(
     private var coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(context.deploymentUrl?.first ?: ""))
     private val linkHandler = CoderProtocolHandler(context, dialogUi, isInitialized)
     override val environments: MutableStateFlow<LoadableState<List<RemoteProviderEnvironment>>> = MutableStateFlow(
-        LoadableState.Value(emptyList())
+        LoadableState.Loading
     )
 
     /**


### PR DESCRIPTION
Closes #44 