### PR TITLE
fix: show login screen when token expires during workspace polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,21 @@
 
 ## Unreleased
 
+### Fixed
+
+- login screen is shown instead of an empty list of workspaces when token expired
+
 ## 0.1.4 - 2025-04-11
 
 ### Fixed
 
-- SSH connection to a Workspace is no longer established only once 
-- authorization wizard automatically goes to a previous screen when an error is encountered during connection to Coder deployment
+- SSH connection to a Workspace is no longer established only once
+- authorization wizard automatically goes to a previous screen when an error is encountered during connection to Coder
+  deployment
 
 ### Changed
 
-- action buttons on the token input step were swapped to achieve better keyboard navigation 
+- action buttons on the token input step were swapped to achieve better keyboard navigation
 - URI `project_path` query parameter was renamed to `folder`
 
 ## 0.1.3 - 2025-04-09

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -2,6 +2,7 @@ package com.coder.toolbox
 
 import com.coder.toolbox.cli.CoderCLIManager
 import com.coder.toolbox.sdk.CoderRestClient
+import com.coder.toolbox.sdk.ex.APIResponseException
 import com.coder.toolbox.sdk.v2.models.WorkspaceStatus
 import com.coder.toolbox.util.CoderProtocolHandler
 import com.coder.toolbox.util.DialogUi
@@ -145,10 +146,17 @@ class CoderRemoteProvider(
                     logout()
                     break
                 }
+            } catch (ex: APIResponseException) {
+                context.logger.error(ex, "error in contacting ${client.url} while polling the available workspaces")
+                pollError = ex
+                logout()
+                goToEnvironmentsPage()
+                break
             } catch (ex: Exception) {
                 context.logger.error(ex, "workspace polling error encountered")
                 pollError = ex
                 logout()
+                goToEnvironmentsPage()
                 break
             }
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -61,7 +61,7 @@ class CoderRemoteProvider(
     // If we have an error in the polling we store it here before going back to
     // sign-in page, so we can display it there.  This is mainly because there
     // does not seem to be a mechanism to show errors on the environment list.
-    private var pollError: Exception? = null
+    private var errorBuffer = mutableListOf<Throwable>()
 
     // On the first load, automatically log in if we can.
     private var firstRun = true
@@ -142,19 +142,19 @@ class CoderRemoteProvider(
                     client.setupSession()
                 } else {
                     context.logger.error(ex, "workspace polling error encountered")
-                    pollError = ex
+                    errorBuffer.add(ex)
                     logout()
                     break
                 }
             } catch (ex: APIResponseException) {
                 context.logger.error(ex, "error in contacting ${client.url} while polling the available workspaces")
-                pollError = ex
+                errorBuffer.add(ex)
                 logout()
                 goToEnvironmentsPage()
                 break
             } catch (ex: Exception) {
                 context.logger.error(ex, "workspace polling error encountered")
-                pollError = ex
+                errorBuffer.add(ex)
                 logout()
                 goToEnvironmentsPage()
                 break
@@ -308,7 +308,6 @@ class CoderRemoteProvider(
         if (client == null) {
             // When coming back to the application, authenticate immediately.
             val autologin = shouldDoAutoLogin()
-            var autologinEx: Exception? = null
             context.secrets.lastToken.let { lastToken ->
                 context.secrets.lastDeploymentURL.let { lastDeploymentURL ->
                     if (autologin && lastDeploymentURL.isNotBlank() && (lastToken.isNotBlank() || !settings.requireTokenAuth)) {
@@ -316,7 +315,7 @@ class CoderRemoteProvider(
                             AuthWizardState.goToStep(WizardStep.LOGIN)
                             return AuthWizardPage(context, true, ::onConnect)
                         } catch (ex: Exception) {
-                            autologinEx = ex
+                            errorBuffer.add(ex)
                         }
                     }
                 }
@@ -325,11 +324,12 @@ class CoderRemoteProvider(
 
             // Login flow.
             val authWizard = AuthWizardPage(context, false, ::onConnect)
-            // We might have tried and failed to automatically log in.
-            autologinEx?.let { authWizard.notify("Error logging in", it) }
             // We might have navigated here due to a polling error.
-            pollError?.let { authWizard.notify("Error fetching workspaces", it) }
-
+            errorBuffer.forEach {
+                authWizard.notify("Error encountered", it)
+            }
+            // and now reset the errors, otherwise we show it every time on the screen
+            errorBuffer.clear()
             return authWizard
         }
         return null
@@ -344,7 +344,7 @@ class CoderRemoteProvider(
         // Currently we always remember, but this could be made an option.
         context.secrets.rememberMe = true
         this.client = client
-        pollError = null
+        errorBuffer.clear()
         pollJob?.cancel()
         pollJob = poll(client, cli)
         goToEnvironmentsPage()

--- a/src/main/kotlin/com/coder/toolbox/sdk/ex/APIResponseException.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/ex/APIResponseException.kt
@@ -1,26 +1,90 @@
 package com.coder.toolbox.sdk.ex
 
+import com.coder.toolbox.sdk.v2.models.ApiErrorResponse
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
-class APIResponseException(action: String, url: URL, res: retrofit2.Response<*>) :
-    IOException(
-        "Unable to $action: url=$url, code=${res.code()}, details=${
-            when (res.code()) {
-                HttpURLConnection.HTTP_NOT_FOUND -> "The requested resource could not be found"
-                else -> res.errorBody()?.charStream()?.use {
-                    val text = it.readText()
-                    // Be careful with the length because if you try to show a
-                    // notification in Toolbox that is too large it crashes the
-                    // application.
-                    if (text.length > 500) {
-                        "${text.substring(0, 500)}…"
-                    } else {
-                        text
-                    }
-                } ?: "no details provided"
-            }}",
-    ) {
-    val isUnauthorized = res.code() == HttpURLConnection.HTTP_UNAUTHORIZED
+class APIResponseException(action: String, url: URL, code: Int, errorResponse: ApiErrorResponse?) :
+    IOException(formatToPretty(action, url, code, errorResponse)) {
+
+
+    val isUnauthorized = HttpURLConnection.HTTP_UNAUTHORIZED == code
+
+    companion object {
+        private fun formatToPretty(
+            action: String,
+            url: URL,
+            code: Int,
+            errorResponse: ApiErrorResponse?,
+        ): String {
+            return if (errorResponse == null) {
+                "Unable to $action: url=$url, code=$code, details=${HttpErrorStatusMapper.getMessage(code)}"
+            } else {
+                var msg = "Unable to $action: url=$url, code=$code, message=${errorResponse.message}"
+                if (errorResponse.detail?.isNotEmpty() == true) {
+                    msg += ", reason=${errorResponse.detail}"
+                }
+
+                // Be careful with the length because if you try to show a
+                // notification in Toolbox that is too large it crashes the
+                // application.
+                if (msg.length > 500) {
+                    msg = "${msg.substring(0, 500)}…"
+                }
+                msg
+            }
+        }
+    }
+}
+
+private object HttpErrorStatusMapper {
+    private val errorStatusMap = mapOf(
+        // 4xx: Client Errors
+        400 to "Bad Request",
+        401 to "Unauthorized",
+        402 to "Payment Required",
+        403 to "Forbidden",
+        404 to "Not Found",
+        405 to "Method Not Allowed",
+        406 to "Not Acceptable",
+        407 to "Proxy Authentication Required",
+        408 to "Request Timeout",
+        409 to "Conflict",
+        410 to "Gone",
+        411 to "Length Required",
+        412 to "Precondition Failed",
+        413 to "Payload Too Large",
+        414 to "URI Too Long",
+        415 to "Unsupported Media Type",
+        416 to "Range Not Satisfiable",
+        417 to "Expectation Failed",
+        418 to "I'm a teapot",
+        421 to "Misdirected Request",
+        422 to "Unprocessable Entity",
+        423 to "Locked",
+        424 to "Failed Dependency",
+        425 to "Too Early",
+        426 to "Upgrade Required",
+        428 to "Precondition Required",
+        429 to "Too Many Requests",
+        431 to "Request Header Fields Too Large",
+        451 to "Unavailable For Legal Reasons",
+
+        // 5xx: Server Errors
+        500 to "Internal Server Error",
+        501 to "Not Implemented",
+        502 to "Bad Gateway",
+        503 to "Service Unavailable",
+        504 to "Gateway Timeout",
+        505 to "HTTP Version Not Supported",
+        506 to "Variant Also Negotiates",
+        507 to "Insufficient Storage",
+        508 to "Loop Detected",
+        510 to "Not Extended",
+        511 to "Network Authentication Required"
+    )
+
+    fun getMessage(code: Int): String =
+        errorStatusMap[code] ?: "Unknown Error Status"
 }

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/ApiErrorResponse.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/ApiErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.coder.toolbox.sdk.v2.models
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ApiErrorResponse(
+    @Json(name = "message") val message: String,
+    @Json(name = "detail") val detail: String?,
+)


### PR DESCRIPTION
- in fact we will now jump to the login screen for any error other than socket timeout because of an OS wake-up
- this patch also contains a re-work of the REST API exception. Coder backend sends very detailed messages with the reason for the http calls to be rejected. We now un-marshall those responses and fill the exception system with better details.