### PR TITLE
fix: simplify and improve error handling during workspace polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - login screen is shown instead of an empty list of workspaces when token expired
 
+### Changed
+
+- improved error handling during workspace polling
+
 ## 0.1.4 - 2025-04-11
 
 ### Fixed


### PR DESCRIPTION
- detect if there is an os wake-up for all types of errors
- if there is an os wake-up we try to re-init the http client.
- if that doesn't work out, the polling stops and redirects to the autologin screen.
- the autologin screen will display an error and stop the authentication if errors are encountered.