### PR TITLE
impl: support for using proxies to access Coder REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- support for using proxies. Proxy authentication is not yet supported.
+
 ## 0.1.5 - 2025-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,42 @@ If `ide_product_code` and `ide_build_number` is missing, Toolbox will only open 
 page. Coder Toolbox will attempt to start the workspace if it’s not already running; however, for the most reliable
 experience, it’s recommended to ensure the workspace is running prior to initiating the connection.
 
+## Configuring and Testing workspace polling with HTTP & SOCKS5 Proxy
+
+This section explains how to set up a local proxy (without authentication which is not yet supported) and verify that
+the plugin’s REST client works correctly when routed through it.
+
+We’ll use [mitmproxy](https://mitmproxy.org/) for this — it can act as both an HTTP and SOCKS5 proxy with SSL
+interception.
+
+### Install mitmproxy
+
+1. Follow the [mitmproxy Install Guide](https://docs.mitmproxy.org/stable/overview-installation/) steps for your OS.
+2. Start the proxy:
+
+```bash
+
+mitmweb --ssl-insecure --set stream_large_bodies="10m"
+ ```
+
+### Configure Proxy
+
+mitmproxy can do HTTP and SOCKS5 proxying. To configure one or the other:
+
+1. Open http://127.0.0.1:8081 in browser;
+2. Navigate to `Options -> Edit Options`
+3. Update the `Mode` field to `regular` in order to activate HTTP/HTTPS or to `socks5`
+4. Proxy authentication can be enabled by updating the `proxyauth` to `username:password`
+
+### Configure Proxy in Toolbox
+
+1. Start Toolbox
+2. From Toolbox hexagonal menu icon go to `Settings -> Proxy`
+3. There are two options, to use system proxy settings or to manually configure the proxy details
+4. If we go manually, add `127.0.0.1` to the host and port `8080` for HTTP/HTTPS or `1080` for SOCKS5.
+5. Before authenticating to the Coder deployment we need to tell the plugin where can we find mitmproxy
+   certificates. In Coder's Settings page, set the `TLS CA path` to `~/.mitmproxy/mitmproxy-ca-cert.pem`
+
 ## Releasing
 
 1. Check that the changelog lists all the important changes.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ interception.
 mitmweb --ssl-insecure --set stream_large_bodies="10m"
  ```
 
-### Configure Proxy
+### Configure Mitmproxy
 
 mitmproxy can do HTTP and SOCKS5 proxying. To configure one or the other:
 
@@ -132,7 +132,7 @@ mitmproxy can do HTTP and SOCKS5 proxying. To configure one or the other:
 
 1. Start Toolbox
 2. From Toolbox hexagonal menu icon go to `Settings -> Proxy`
-3. There are two options, to use system proxy settings or to manually configure the proxy details
+3. There are two options, to use system proxy settings or to manually configure the proxy details.
 4. If we go manually, add `127.0.0.1` to the host and port `8080` for HTTP/HTTPS or `1080` for SOCKS5.
 5. Before authenticating to the Coder deployment we need to tell the plugin where can we find mitmproxy
    certificates. In Coder's Settings page, set the `TLS CA path` to `~/.mitmproxy/mitmproxy-ca-cert.pem`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.1.5
+version=0.2.0
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
@@ -7,6 +7,7 @@ import com.coder.toolbox.util.toURL
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
+import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
 import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateColorPalette
 import com.jetbrains.toolbox.api.remoteDev.ui.EnvironmentUiPageManager
 import com.jetbrains.toolbox.api.ui.ToolboxUi
@@ -21,7 +22,8 @@ data class CoderToolboxContext(
     val logger: Logger,
     val i18n: LocalizableStringFactory,
     val settingsStore: CoderSettingsStore,
-    val secrets: CoderSecretsStore
+    val secrets: CoderSecretsStore,
+    val proxySettings: ToolboxProxySettings,
 ) {
     /**
      * Try to find a URL.

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
@@ -7,10 +7,12 @@ import com.jetbrains.toolbox.api.core.PluginSecretStore
 import com.jetbrains.toolbox.api.core.PluginSettingsStore
 import com.jetbrains.toolbox.api.core.ServiceLocator
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
+import com.jetbrains.toolbox.api.core.getService
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.RemoteDevExtension
 import com.jetbrains.toolbox.api.remoteDev.RemoteProvider
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
+import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
 import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateColorPalette
 import com.jetbrains.toolbox.api.remoteDev.ui.EnvironmentUiPageManager
 import com.jetbrains.toolbox.api.ui.ToolboxUi
@@ -25,15 +27,16 @@ class CoderToolboxExtension : RemoteDevExtension {
         val logger = serviceLocator.getService(Logger::class.java)
         return CoderRemoteProvider(
             CoderToolboxContext(
-                serviceLocator.getService(ToolboxUi::class.java),
-                serviceLocator.getService(EnvironmentUiPageManager::class.java),
-                serviceLocator.getService(EnvironmentStateColorPalette::class.java),
-                serviceLocator.getService(ClientHelper::class.java),
-                serviceLocator.getService(CoroutineScope::class.java),
-                serviceLocator.getService(Logger::class.java),
-                serviceLocator.getService(LocalizableStringFactory::class.java),
-                CoderSettingsStore(serviceLocator.getService(PluginSettingsStore::class.java), Environment(), logger),
-                CoderSecretsStore(serviceLocator.getService(PluginSecretStore::class.java)),
+                serviceLocator.getService<ToolboxUi>(),
+                serviceLocator.getService<EnvironmentUiPageManager>(),
+                serviceLocator.getService<EnvironmentStateColorPalette>(),
+                serviceLocator.getService<ClientHelper>(),
+                serviceLocator.getService<CoroutineScope>(),
+                serviceLocator.getService<Logger>(),
+                serviceLocator.getService<LocalizableStringFactory>(),
+                CoderSettingsStore(serviceLocator.getService<PluginSettingsStore>(), Environment(), logger),
+                CoderSecretsStore(serviceLocator.getService<PluginSecretStore>()),
+                serviceLocator.getService<ToolboxProxySettings>()
             )
         )
     }

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -238,13 +238,10 @@ open class CoderProtocolHandler(
         if (settings.requireTokenAuth && token == null) { // User aborted.
             throw MissingArgumentException("Token is required")
         }
-        // The http client Toolbox gives us is already set up with the
-        // proxy config, so we do net need to explicitly add it.
         val client = CoderRestClient(
             context,
             deploymentURL.toURL(),
             token,
-            proxyValues = null, // TODO - not sure the above comment applies as we are creating our own http client
             PluginManager.pluginInfo.version
         )
         client.authenticate()

--- a/src/main/kotlin/com/coder/toolbox/views/ConnectStep.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/ConnectStep.kt
@@ -74,13 +74,10 @@ class ConnectStep(
         signInJob = context.cs.launch {
             try {
                 statusField.textState.update { (context.i18n.ptrl("Authenticating to ${url.host}...")) }
-                // The http client Toolbox gives us is already set up with the
-                // proxy config, so we do net need to explicitly add it.
                 val client = CoderRestClient(
                     context,
                     url,
                     token,
-                    proxyValues = null,
                     PluginManager.pluginInfo.version,
                 )
                 // allows interleaving with the back/cancel action

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -30,6 +30,7 @@ import com.coder.toolbox.util.toURL
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
+import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
 import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentStateColorPalette
 import com.jetbrains.toolbox.api.remoteDev.ui.EnvironmentUiPageManager
 import com.jetbrains.toolbox.api.ui.ToolboxUi
@@ -68,7 +69,8 @@ internal class CoderCLIManagerTest {
             Environment(),
             mockk<Logger>(relaxed = true)
         ),
-        mockk<CoderSecretsStore>()
+        mockk<CoderSecretsStore>(),
+        mockk<ToolboxProxySettings>()
     )
 
     /**


### PR DESCRIPTION
- proxy credentials are not yet supported as they were not exposed in Toolbox settings
- system and manual proxy configuration supported.
- manual tests included system wide settings and manual http settings.
- resolves #39
