### PR TITLE
fix: agent error reporting and handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - support for using proxies. Proxy authentication is not yet supported.
 
+### Changed
+
+- connections to the workspace are no longer established automatically after agent started with error.
+
 ## 0.1.5 - 2025-04-14
 
 ### Fixed

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -144,8 +144,8 @@ open class CoderProtocolHandler(
         val status = WorkspaceAndAgentStatus.from(workspace, agent)
 
         if (!status.ready()) {
-            context.logger.error("Agent ${agent.name} for workspace $workspaceName from $deploymentURL is not started")
-            context.showErrorPopup(MissingArgumentException("Can't handle URI because agent ${agent.name} for workspace $workspaceName from $deploymentURL is not started"))
+            context.logger.error("Agent ${agent.name} for workspace $workspaceName from $deploymentURL is not ready")
+            context.showErrorPopup(MissingArgumentException("Can't handle URI because agent ${agent.name} for workspace $workspaceName from $deploymentURL is not ready"))
             return
         }
 


### PR DESCRIPTION
- if workspace or agent start with error, we report the workspace as started with errors and highlight the text with red.
- the workspace is still marked as reachable even though it is unhealthy but we no longer connect automatically to the workspace via ssh when user selects the workspace from the env list.