### PR TITLE
chore: remove ssh background config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- ssh configuration is simplified, background hostnames have been discarded.
+
 ## 0.2.0 - 2025-04-24
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.2.0
+version=0.2.1
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -301,19 +301,8 @@ class CoderCLIManager(
                     """.trimIndent()
                         .plus("\n" + options.prependIndent("  "))
                         .plus(extraConfig)
-                        .plus("\n\n")
-                        .plus(
-                            """
-                            Host ${getBackgroundHostnamePrefix(deploymentURL)}--*
-                              ProxyCommand ${backgroundProxyArgs.joinToString(" ")} --ssh-host-prefix ${
-                                getBackgroundHostnamePrefix(
-                                    deploymentURL
-                                )
-                            }-- %h
-                            """.trimIndent()
-                                .plus("\n" + options.prependIndent("  "))
-                                .plus(extraConfig),
-                        ).replace("\n", System.lineSeparator()) +
+                        .plus("\n")
+                        .replace("\n", System.lineSeparator()) +
                     System.lineSeparator() + endBlock
         } else {
             wsWithAgents.joinToString(
@@ -328,19 +317,7 @@ class CoderCLIManager(
                         .plus("\n" + options.prependIndent("  "))
                         .plus(extraConfig)
                         .plus("\n")
-                        .plus(
-                            """
-                            Host ${getBackgroundHostname(deploymentURL, it.workspace(), it.agent())}
-                              ProxyCommand ${backgroundProxyArgs.joinToString(" ")} ${
-                                getWsByOwner(
-                                    it.workspace(),
-                                    it.agent()
-                                )
-                            }
-                            """.trimIndent()
-                                .plus("\n" + options.prependIndent("  "))
-                                .plus(extraConfig),
-                        ).replace("\n", System.lineSeparator())
+                        .replace("\n", System.lineSeparator())
                 },
             )
         }
@@ -519,16 +496,10 @@ class CoderCLIManager(
         }
     }
 
-    fun getBackgroundHostname(url: URL, ws: Workspace, agent: WorkspaceAgent): String {
-        return "${getHostname(url, ws, agent)}--bg"
-    }
-
     companion object {
         private val tokenRegex = "--token [^ ]+".toRegex()
 
         private fun getHostnamePrefix(url: URL): String = "coder-jetbrains-toolbox-${url.safeHost()}"
-
-        private fun getBackgroundHostnamePrefix(url: URL): String = "coder-jetbrains-toolbox-${url.safeHost()}-bg"
 
         private fun getWsByOwner(ws: Workspace, agent: WorkspaceAgent): String =
             "${ws.ownerName}/${ws.name}.${agent.name}"

--- a/src/test/resources/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/resources/fixtures/outputs/append-blank-newlines.conf
@@ -10,11 +10,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/append-blank.conf
+++ b/src/test/resources/fixtures/outputs/append-blank.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/resources/fixtures/outputs/append-no-blocks.conf
@@ -11,11 +11,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/append-no-newline.conf
+++ b/src/test/resources/fixtures/outputs/append-no-newline.conf
@@ -10,11 +10,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/resources/fixtures/outputs/append-no-related-blocks.conf
@@ -17,11 +17,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/disable-autostart.conf
+++ b/src/test/resources/fixtures/outputs/disable-autostart.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --disable-autostart --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/extra-config.conf
+++ b/src/test/resources/fixtures/outputs/extra-config.conf
@@ -8,13 +8,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
   ServerAliveInterval 5
   ServerAliveCountMax 3
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-  ServerAliveInterval 5
-  ServerAliveCountMax 3
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/header-command-windows.conf
+++ b/src/test/resources/fixtures/outputs/header-command-windows.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/header-command.conf
+++ b/src/test/resources/fixtures/outputs/header-command.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/log-dir.conf
+++ b/src/test/resources/fixtures/outputs/log-dir.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/multiple-agents.conf
+++ b/src/test/resources/fixtures/outputs/multiple-agents.conf
@@ -6,13 +6,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 Host coder-jetbrains-toolbox--owner--foo.agent2--test.coder.invalid
   ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent2
   ConnectTimeout 0
@@ -20,11 +14,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent2--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent2--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent2
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/multiple-users.conf
+++ b/src/test/resources/fixtures/outputs/multiple-users.conf
@@ -6,13 +6,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
@@ -20,11 +14,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/resources/fixtures/outputs/multiple-workspaces.conf
@@ -6,13 +6,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 Host coder-jetbrains-toolbox--owner--bar.agent1--test.coder.invalid
   ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/bar.agent1
   ConnectTimeout 0
@@ -20,11 +14,5 @@ Host coder-jetbrains-toolbox--owner--bar.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--bar.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/bar.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/no-disable-autostart.conf
+++ b/src/test/resources/fixtures/outputs/no-disable-autostart.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/no-report-usage.conf
+++ b/src/test/resources/fixtures/outputs/no-report-usage.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/resources/fixtures/outputs/replace-end-no-newline.conf
@@ -9,11 +9,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/replace-end.conf
+++ b/src/test/resources/fixtures/outputs/replace-end.conf
@@ -10,11 +10,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/resources/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -11,13 +11,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid
 Host test2
   Port 443

--- a/src/test/resources/fixtures/outputs/replace-middle.conf
+++ b/src/test/resources/fixtures/outputs/replace-middle.conf
@@ -8,13 +8,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid
 Host test2
   Port 443

--- a/src/test/resources/fixtures/outputs/replace-only.conf
+++ b/src/test/resources/fixtures/outputs/replace-only.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/replace-start.conf
+++ b/src/test/resources/fixtures/outputs/replace-start.conf
@@ -6,13 +6,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid
 Host test
   Port 80

--- a/src/test/resources/fixtures/outputs/url.conf
+++ b/src/test/resources/fixtures/outputs/url.conf
@@ -6,11 +6,5 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid?foo=bar&baz=qux ssh --stdio --usage-app=disable owner/foo.agent1
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid

--- a/src/test/resources/fixtures/outputs/wildcard.conf
+++ b/src/test/resources/fixtures/outputs/wildcard.conf
@@ -7,11 +7,4 @@ Host coder-jetbrains-toolbox-test.coder.invalid--*
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 
-Host coder-jetbrains-toolbox-test.coder.invalid-bg--*
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --ssh-host-prefix coder-jetbrains-toolbox-test.coder.invalid-bg-- %h
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS TOOLBOX test.coder.invalid


### PR DESCRIPTION
From my testing, Toolbox forwards through SSH (i.e. through Coder) a remote port associated with the IDE
running in server mode, to localhost in order for the server (i.e. the remote IDE) to communicate with
JBClient. Unlike with Gateway, Toolbox manages to reuse the SSH connection, and it doesn't open a separate
one for port forwarding.

From Gateway we inherited two ssh hostnames per each workspace, one for background connections that did not
involve running IDEs. Coder discards the bg. connection from the collected metrics in order to
avoid double counting. Since Toolbox manages to re-use the connection we don't need to worry
about double counting.

For this particular change, I deployed the latest Coder version with prometheus metrics and experiments
enabled (i.e. --prometheus-enable --prometheus-collect-agent-stats --experiments=workspace-usage) and made the following experiment:

1. Opened up Toolbox, logged into Coder. At this point:
- agent_sessions_total and coderd_agentstats_session_count_jetbrains were missing from prometheus metrics
- jetbrains session count from api/v2/deployment/stats showed 0

2. Opened up a Workspace at which point Toolbox established the SSH connection:
- agent_sessions_total and coderd_agentstats_session_count_jetbrains increased to 1
- jetbrains session count from api/v2/deployment/stats increased to 1 as well

3. Hit the install button on RustRover, everything stayed unchanged

4. Open RustRover, nothing changes in the stats.