### PR TITLE
fix: misleading "No workspaces yet" during manual authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - ssh configuration is simplified, background hostnames have been discarded.
 
+### Fixed
+
+- misleading message saying that there are no workspaces rendered during manual authentication 
+
 ## 0.2.0 - 2025-04-24
 
 ### Added

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -262,9 +262,7 @@ class CoderRemoteProvider(
             // start initialization with the new settings
             this@CoderRemoteProvider.client = restClient
             coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(restClient.url.toString()))
-            environments.update {
-                LoadableState.Loading
-            }
+            environments.showLoadingMessage()
             pollJob = poll(restClient, cli)
         }
     }
@@ -329,11 +327,14 @@ class CoderRemoteProvider(
         context.secrets.rememberMe = true
         this.client = client
         pollJob?.cancel()
-
-        environments.update {
-            LoadableState.Loading
-        }
+        environments.showLoadingMessage()
         pollJob = poll(client, cli)
         goToEnvironmentsPage()
+    }
+
+    private fun MutableStateFlow<LoadableState<List<RemoteProviderEnvironment>>>.showLoadingMessage() {
+        this.update {
+            LoadableState.Loading
+        }
     }
 }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -262,6 +262,9 @@ class CoderRemoteProvider(
             // start initialization with the new settings
             this@CoderRemoteProvider.client = restClient
             coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(restClient.url.toString()))
+            environments.update {
+                LoadableState.Loading
+            }
             pollJob = poll(restClient, cli)
         }
     }
@@ -326,6 +329,10 @@ class CoderRemoteProvider(
         context.secrets.rememberMe = true
         this.client = client
         pollJob?.cancel()
+
+        environments.update {
+            LoadableState.Loading
+        }
         pollJob = poll(client, cli)
         goToEnvironmentsPage()
     }


### PR DESCRIPTION
There is a brief moment between manual authentication and workspace poller initialization and execution where we see a "No workspaces yet" which is misleading. Instead, a loading indicator/message  should be displayed.

- resolves #103 