### PR TITLE
fix: access the settings page for the auth. wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - rendering glitches when a Workspace is stopped while SSH connection is alive
 - misleading message saying that there are no workspaces rendered during manual authentication
+- Coder Settings can now be accessed from the authentication wizard
 
 ## 0.2.0 - 2025-04-24
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -296,7 +296,7 @@ class CoderRemoteProvider(
                     if (autologin && lastDeploymentURL.isNotBlank() && (lastToken.isNotBlank() || !settings.requireTokenAuth)) {
                         try {
                             AuthWizardState.goToStep(WizardStep.LOGIN)
-                            return AuthWizardPage(context, true, ::onConnect)
+                            return AuthWizardPage(context, settingsPage, true, ::onConnect)
                         } catch (ex: Exception) {
                             errorBuffer.add(ex)
                         }
@@ -306,7 +306,7 @@ class CoderRemoteProvider(
             firstRun = false
 
             // Login flow.
-            val authWizard = AuthWizardPage(context, false, ::onConnect)
+            val authWizard = AuthWizardPage(context, settingsPage, false, ::onConnect)
             // We might have navigated here due to a polling error.
             errorBuffer.forEach {
                 authWizard.notify("Error encountered", it)

--- a/src/main/kotlin/com/coder/toolbox/views/AuthWizardPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/AuthWizardPage.kt
@@ -12,14 +12,17 @@ import kotlinx.coroutines.flow.update
 
 class AuthWizardPage(
     private val context: CoderToolboxContext,
+    private val settingsPage: CoderSettingsPage,
     initialAutoLogin: Boolean = false,
     onConnect: (
         client: CoderRestClient,
         cli: CoderCLIManager,
     ) -> Unit,
-) : CoderPage(context, context.i18n.ptrl("Authenticate to Coder")) {
+) : CoderPage(context, context.i18n.ptrl("Authenticate to Coder"), false) {
     private val shouldAutoLogin = MutableStateFlow(initialAutoLogin)
-
+    private val settingsAction = Action(context.i18n.ptrl("Settings"), actionBlock = {
+        context.ui.showUiPage(settingsPage)
+    })
     private val signInStep = SignInStep(context, this::notify)
     private val tokenStep = TokenStep(context)
     private val connectStep = ConnectStep(context, shouldAutoLogin, this::notify, this::displaySteps, onConnect)
@@ -47,7 +50,8 @@ class AuthWizardPage(
                             if (signInStep.onNext()) {
                                 displaySteps()
                             }
-                        })
+                        }),
+                        settingsAction
                     )
                 }
                 signInStep.onVisible()
@@ -64,6 +68,7 @@ class AuthWizardPage(
                                 displaySteps()
                             }
                         }),
+                        settingsAction,
                         Action(context.i18n.ptrl("Back"), closesPage = false, actionBlock = {
                             tokenStep.onBack()
                             displaySteps()
@@ -79,6 +84,7 @@ class AuthWizardPage(
                 }
                 actionButtons.update {
                     listOf(
+                        settingsAction,
                         Action(context.i18n.ptrl("Back"), closesPage = false, actionBlock = {
                             connectStep.onBack()
                             shouldAutoLogin.update {


### PR DESCRIPTION
The Settings menu is only available after we successfully authenticate. This can be somewhat problematic if we want to configure something like coder cli path, or certificate path before doing the authentication.

A new "Settings" button at the bottom of the page can now access the Settings page. Toolbox is a bit inflexible with the API because:
- I could not find a way to delimit or separate the Settings button from the Back and Sign In/Connect button
- we can't put a button or anything else in the top right corner, the traditional place for a settings icon.

- resolves #90