### PR TITLE
impl: support for displaying network latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- render network status in the Settings tab, under `Additional environment information` section.
+
 ## 0.2.1 - 2025-05-05
 
 ### Changed

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -180,7 +180,7 @@ class CoderRemoteEnvironment(
                     return@launch
                 }
                 context.logger.debug("$id metrics: $metrics")
-                additionalEnvironmentInformation.put(context.i18n.ptrl("Network Metrics"), metrics.toPretty())
+                additionalEnvironmentInformation.put(context.i18n.ptrl("Network Status"), metrics.toPretty())
             } catch (e: Exception) {
                 context.logger.error(
                     e,

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -277,8 +277,6 @@ class CoderCLIManager(
             if (!settings.sshLogDirectory.isNullOrBlank()) escape(settings.sshLogDirectory!!) else null,
             if (feats.reportWorkspaceUsage) "--usage-app=jetbrains" else null,
         )
-        val backgroundProxyArgs =
-            baseArgs + listOfNotNull(if (feats.reportWorkspaceUsage) "--usage-app=disable" else null)
         val extraConfig =
             if (!settings.sshConfigOptions.isNullOrBlank()) {
                 "\n" + settings.sshConfigOptions!!.prependIndent("  ")

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -271,6 +271,7 @@ class CoderCLIManager(
                 "ssh",
                 "--stdio",
                 if (settings.disableAutostart && feats.disableAutostart) "--disable-autostart" else null,
+                "--network-info-dir ${escape(settings.networkInfoDir)}"
             )
         val proxyArgs = baseArgs + listOfNotNull(
             if (!settings.sshLogDirectory.isNullOrBlank()) "--log-dir" else null,

--- a/src/main/kotlin/com/coder/toolbox/cli/SshCommandProcessHandle.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/SshCommandProcessHandle.kt
@@ -1,0 +1,42 @@
+package com.coder.toolbox.cli
+
+import com.coder.toolbox.CoderToolboxContext
+import com.coder.toolbox.sdk.v2.models.Workspace
+import com.coder.toolbox.sdk.v2.models.WorkspaceAgent
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Identifies the PID for the SSH Coder command spawned by Toolbox.
+ */
+class SshCommandProcessHandle(private val ctx: CoderToolboxContext) {
+
+    /**
+     * Finds the PID of a Coder (not the proxy command) ssh cmd associated with the specified workspace and agent.
+     * Null is returned when no ssh command process was found.
+     *
+     * Implementation Notes:
+     * An iterative DFS approach where we start with Toolbox's direct children, grep the command
+     * and if nothing is found we continue with the processes children. Toolbox spawns an ssh command
+     * as a separate command which in turns spawns another child for the proxy command.
+     */
+    fun findByWorkspaceAndAgent(ws: Workspace, agent: WorkspaceAgent): Long? {
+        val stack = ArrayDeque<ProcessHandle>(ProcessHandle.current().children().toList())
+        while (stack.isNotEmpty()) {
+            val processHandle = stack.removeLast()
+            val cmdLine = processHandle.info().commandLine().getOrNull()
+            ctx.logger.debug("SSH command PID: ${processHandle.pid()} Command: $cmdLine")
+            if (cmdLine != null && cmdLine.isSshCommandFor(ws, agent)) {
+                ctx.logger.debug("SSH command with PID: ${processHandle.pid()} and Command: $cmdLine matches ${ws.name}.${agent.name}")
+                return processHandle.pid()
+            } else {
+                stack.addAll(processHandle.children().toList())
+            }
+        }
+        return null
+    }
+
+    private fun String.isSshCommandFor(ws: Workspace, agent: WorkspaceAgent): Boolean {
+        // usage-app is present only in the ProxyCommand
+        return !this.contains("--usage-app=jetbrains") && this.contains("${ws.name}.${agent.name}")
+    }
+}

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
@@ -1,0 +1,33 @@
+package com.coder.toolbox.sdk.v2.models
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Coder ssh network metrics. All properties are optional
+ * because Coder Connect only populates `using_coder_connect`
+ * while p2p doesn't populate this property.
+ */
+@JsonClass(generateAdapter = true)
+data class NetworkMetrics(
+    @Json(name = "p2p")
+    val p2p: Boolean?,
+
+    @Json(name = "latency")
+    val latency: Double?,
+
+    @Json(name = "preferred_derp")
+    val preferredDerp: String?,
+
+    @Json(name = "derp_latency")
+    val derpLatency: Map<String, Double>?,
+
+    @Json(name = "upload_bytes_sec")
+    val uploadBytesSec: Long?,
+
+    @Json(name = "download_bytes_sec")
+    val downloadBytesSec: Long?,
+
+    @Json(name = "using_coder_connect")
+    val usingCoderConnect: Boolean?
+)

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
@@ -30,4 +30,12 @@ data class NetworkMetrics(
 
     @Json(name = "using_coder_connect")
     val usingCoderConnect: Boolean?
-)
+) {
+    fun toPretty(): String {
+        return if (p2p == true) {
+            "Direct (${latency}ms) \u00B7 Download \u2193 $downloadBytesSec b/s \u00B7 Upload \u2191 $uploadBytesSec b/s"
+        } else {
+            "$preferredDerp (${latency}ms) \u00B7 Download \u2193 $downloadBytesSec b/s \u00B7 Upload \u2191 $uploadBytesSec b/s"
+        }
+    }
+}

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetrics.kt
@@ -2,6 +2,9 @@ package com.coder.toolbox.sdk.v2.models
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.text.DecimalFormat
+
+private val formatter = DecimalFormat("#.00")
 
 /**
  * Coder ssh network metrics. All properties are optional
@@ -32,10 +35,15 @@ data class NetworkMetrics(
     val usingCoderConnect: Boolean?
 ) {
     fun toPretty(): String {
+        if (usingCoderConnect == true) {
+            return "You're connected using Coder Connect"
+        }
         return if (p2p == true) {
-            "Direct (${latency}ms) \u00B7 Download \u2193 $downloadBytesSec b/s \u00B7 Upload \u2191 $uploadBytesSec b/s"
+            "Direct (${formatter.format(latency)}ms). You're connected peer-to-peer"
         } else {
-            "$preferredDerp (${latency}ms) \u00B7 Download \u2193 $downloadBytesSec b/s \u00B7 Upload \u2191 $uploadBytesSec b/s"
+            val derpLatency = derpLatency!![preferredDerp]
+            val workspaceLatency = latency!!.minus(derpLatency!!)
+            "You ↔ $preferredDerp (${formatter.format(derpLatency)}ms) ↔ Workspace (${formatter.format(workspaceLatency)}ms). You are connected through a relay"
         }
     }
 }

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -110,6 +110,12 @@ interface ReadOnlyCoderSettings {
      */
     val sshConfigOptions: String?
 
+
+    /**
+     * The path where network information for SSH hosts are stored
+     */
+    val networkInfoDir: String
+
     /**
      * The default URL to show in the connection window.
      */

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -65,6 +65,11 @@ class CoderSettingsStore(
     override val sshLogDirectory: String? get() = store[SSH_LOG_DIR]
     override val sshConfigOptions: String?
         get() = store[SSH_CONFIG_OPTIONS].takeUnless { it.isNullOrEmpty() } ?: env.get(CODER_SSH_CONFIG_OPTIONS)
+    override val networkInfoDir: String
+        get() = store[NETWORK_INFO_DIR].takeUnless { it.isNullOrEmpty() } ?: getDefaultGlobalDataDir()
+            .resolve("network-info")
+            .normalize()
+            .toString()
 
     /**
      * The default URL to show in the connection window.

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -237,6 +237,10 @@ class CoderSettingsStore(
         store[SSH_LOG_DIR] = path
     }
 
+    fun updateNetworkInfoDir(path: String) {
+        store[NETWORK_INFO_DIR] = path
+    }
+
     fun updateSshConfigOptions(options: String) {
         store[SSH_CONFIG_OPTIONS] = options
     }

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -67,7 +67,7 @@ class CoderSettingsStore(
         get() = store[SSH_CONFIG_OPTIONS].takeUnless { it.isNullOrEmpty() } ?: env.get(CODER_SSH_CONFIG_OPTIONS)
     override val networkInfoDir: String
         get() = store[NETWORK_INFO_DIR].takeUnless { it.isNullOrEmpty() } ?: getDefaultGlobalDataDir()
-            .resolve("network-info")
+            .resolve("ssh-network-metrics")
             .normalize()
             .toString()
 

--- a/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
@@ -38,3 +38,5 @@ internal const val SSH_LOG_DIR = "sshLogDir"
 
 internal const val SSH_CONFIG_OPTIONS = "sshConfigOptions"
 
+internal const val NETWORK_INFO_DIR = "networkInfoDir"
+

--- a/src/main/kotlin/com/coder/toolbox/views/CoderSettingsPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/CoderSettingsPage.kt
@@ -56,6 +56,8 @@ class CoderSettingsPage(context: CoderToolboxContext, triggerSshConfig: Channel<
         TextField(context.i18n.ptrl("Extra SSH options"), settings.sshConfigOptions ?: "", TextType.General)
     private val sshLogDirField =
         TextField(context.i18n.ptrl("SSH proxy log directory"), settings.sshLogDirectory ?: "", TextType.General)
+    private val networkInfoDirField =
+        TextField(context.i18n.ptrl("SSH network metrics directory"), settings.networkInfoDir, TextType.General)
 
 
     override val fields: StateFlow<List<UiField>> = MutableStateFlow(
@@ -73,6 +75,7 @@ class CoderSettingsPage(context: CoderToolboxContext, triggerSshConfig: Channel<
             disableAutostartField,
             enableSshWildCardConfig,
             sshLogDirField,
+            networkInfoDirField,
             sshExtraArgs,
         )
     )
@@ -104,6 +107,7 @@ class CoderSettingsPage(context: CoderToolboxContext, triggerSshConfig: Channel<
                     }
                 }
                 context.settingsStore.updateSshLogDir(sshLogDirField.textState.value)
+                context.settingsStore.updateNetworkInfoDir(networkInfoDirField.textState.value)
                 context.settingsStore.updateSshConfigOptions(sshExtraArgs.textState.value)
             }
         )

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -129,3 +129,6 @@ msgstr ""
 
 msgid "SSH proxy log directory"
 msgstr ""
+
+msgid "SSH network metrics directory"
+msgstr ""

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -132,3 +132,6 @@ msgstr ""
 
 msgid "SSH network metrics directory"
 msgstr ""
+
+msgid "Network Metrics"
+msgstr ""

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -133,5 +133,5 @@ msgstr ""
 msgid "SSH network metrics directory"
 msgstr ""
 
-msgid "Network Metrics"
+msgid "Network Status"
 msgstr ""

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -18,6 +18,7 @@ import com.coder.toolbox.store.DISABLE_AUTOSTART
 import com.coder.toolbox.store.ENABLE_BINARY_DIR_FALLBACK
 import com.coder.toolbox.store.ENABLE_DOWNLOADS
 import com.coder.toolbox.store.HEADER_COMMAND
+import com.coder.toolbox.store.NETWORK_INFO_DIR
 import com.coder.toolbox.store.SSH_CONFIG_OPTIONS
 import com.coder.toolbox.store.SSH_CONFIG_PATH
 import com.coder.toolbox.store.SSH_LOG_DIR
@@ -510,7 +511,10 @@ internal class CoderCLIManagerTest {
                         HEADER_COMMAND to it.headerCommand,
                         SSH_CONFIG_PATH to tmpdir.resolve(it.input + "_to_" + it.output + ".conf").toString(),
                         SSH_CONFIG_OPTIONS to it.extraConfig,
-                        SSH_LOG_DIR to (it.sshLogDirectory?.toString() ?: "")
+                        SSH_LOG_DIR to (it.sshLogDirectory?.toString() ?: ""),
+                        NETWORK_INFO_DIR to tmpdir.parent.resolve("coder-toolbox")
+                            .resolve("ssh-network-metrics")
+                            .normalize().toString()
                     ),
                     env = it.env,
                     context.logger,
@@ -531,6 +535,7 @@ internal class CoderCLIManagerTest {
 
             // Output is the configuration we expect to have after configuring.
             val coderConfigPath = ccm.localBinaryPath.parent.resolve("config")
+            val networkMetricsPath = tmpdir.parent.resolve("coder-toolbox").resolve("ssh-network-metrics")
             val expectedConf =
                 Path.of("src/test/resources/fixtures/outputs/").resolve(it.output + ".conf").toFile().readText()
                     .replace(newlineRe, System.lineSeparator())
@@ -538,6 +543,10 @@ internal class CoderCLIManagerTest {
                     .replace(
                         "/tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64",
                         escape(ccm.localBinaryPath.toString())
+                    )
+                    .replace(
+                        "/tmp/coder-toolbox/ssh-network-metrics",
+                        escape(networkMetricsPath.toString())
                     )
                     .let { conf ->
                         if (it.sshLogDirectory != null) {

--- a/src/test/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetricsTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/sdk/v2/models/NetworkMetricsTest.kt
@@ -1,0 +1,107 @@
+package com.coder.toolbox.sdk.v2.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NetworkMetricsTest {
+
+    @Test
+    fun `toPretty should return message for Coder Connect`() {
+        val metrics = NetworkMetrics(
+            p2p = null,
+            latency = null,
+            preferredDerp = null,
+            derpLatency = null,
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = true
+        )
+
+        val expected = "You're connected using Coder Connect"
+        assertEquals(expected, metrics.toPretty())
+    }
+
+    @Test
+    fun `toPretty should return message for P2P connection`() {
+        val metrics = NetworkMetrics(
+            p2p = true,
+            latency = 35.526,
+            preferredDerp = null,
+            derpLatency = null,
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = false
+        )
+
+        val expected = "Direct (35.53ms). You're connected peer-to-peer"
+        assertEquals(expected, metrics.toPretty())
+    }
+
+    @Test
+    fun `toPretty should round latency with more than two decimals correctly for P2P`() {
+        val metrics = NetworkMetrics(
+            p2p = true,
+            latency = 42.6789,
+            preferredDerp = null,
+            derpLatency = null,
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = false
+        )
+
+        val expected = "Direct (42.68ms). You're connected peer-to-peer"
+        assertEquals(expected, metrics.toPretty())
+    }
+
+    @Test
+    fun `toPretty should pad latency with one decimal correctly for P2P`() {
+        val metrics = NetworkMetrics(
+            p2p = true,
+            latency = 12.5,
+            preferredDerp = null,
+            derpLatency = null,
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = false
+        )
+
+        val expected = "Direct (12.50ms). You're connected peer-to-peer"
+        assertEquals(expected, metrics.toPretty())
+    }
+
+    @Test
+    fun `toPretty should return message for DERP relay connection`() {
+        val metrics = NetworkMetrics(
+            p2p = false,
+            latency = 80.0,
+            preferredDerp = "derp1",
+            derpLatency = mapOf("derp1" to 30.0),
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = false
+        )
+
+        val expected = "You ↔ derp1 (30.00ms) ↔ Workspace (50.00ms). You are connected through a relay"
+        assertEquals(expected, metrics.toPretty())
+    }
+
+    @Test
+    fun `toPretty should round and pad latencies correctly for DERP`() {
+        val metrics = NetworkMetrics(
+            p2p = false,
+            latency = 78.1267,
+            preferredDerp = "derp2",
+            derpLatency = mapOf("derp2" to 23.5),
+            uploadBytesSec = null,
+            downloadBytesSec = null,
+            usingCoderConnect = false
+        )
+
+        // Total latency: 78.1267
+        // DERP latency: 23.5 → formatted as 23.50
+        // Workspace latency: 78.1267 - 23.5 = 54.6267 → formatted as 54.63
+
+        val expected = "You ↔ derp2 (23.50ms) ↔ Workspace (54.63ms). You are connected through a relay"
+        assertEquals(expected, metrics.toPretty())
+    }
+}

--- a/src/test/resources/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/resources/fixtures/outputs/append-blank-newlines.conf
@@ -4,7 +4,7 @@
 
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/append-blank.conf
+++ b/src/test/resources/fixtures/outputs/append-blank.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/resources/fixtures/outputs/append-no-blocks.conf
@@ -5,7 +5,7 @@ Host test2
 
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/append-no-newline.conf
+++ b/src/test/resources/fixtures/outputs/append-no-newline.conf
@@ -4,7 +4,7 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/resources/fixtures/outputs/append-no-related-blocks.conf
@@ -11,7 +11,7 @@ some jetbrains config
 
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/disable-autostart.conf
+++ b/src/test/resources/fixtures/outputs/disable-autostart.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --disable-autostart --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --disable-autostart --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/extra-config.conf
+++ b/src/test/resources/fixtures/outputs/extra-config.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/header-command-windows.conf
+++ b/src/test/resources/fixtures/outputs/header-command-windows.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/header-command.conf
+++ b/src/test/resources/fixtures/outputs/header-command.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/log-dir.conf
+++ b/src/test/resources/fixtures/outputs/log-dir.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --log-dir /tmp/coder-toolbox/test.coder.invalid/logs --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --log-dir /tmp/coder-toolbox/test.coder.invalid/logs --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/multiple-agents.conf
+++ b/src/test/resources/fixtures/outputs/multiple-agents.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
@@ -8,7 +8,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 
 Host coder-jetbrains-toolbox--owner--foo.agent2--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent2
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent2
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/multiple-users.conf
+++ b/src/test/resources/fixtures/outputs/multiple-users.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
@@ -8,7 +8,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/resources/fixtures/outputs/multiple-workspaces.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
@@ -8,7 +8,7 @@ Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 
 Host coder-jetbrains-toolbox--owner--bar.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/bar.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/bar.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/no-disable-autostart.conf
+++ b/src/test/resources/fixtures/outputs/no-disable-autostart.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/no-report-usage.conf
+++ b/src/test/resources/fixtures/outputs/no-report-usage.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/resources/fixtures/outputs/replace-end-no-newline.conf
@@ -3,7 +3,7 @@ Host test
 Host test2
   Port 443 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-end.conf
+++ b/src/test/resources/fixtures/outputs/replace-end.conf
@@ -4,7 +4,7 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/resources/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -5,7 +5,7 @@ some coder config
 # ------------END-CODER------------
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-middle.conf
+++ b/src/test/resources/fixtures/outputs/replace-middle.conf
@@ -2,7 +2,7 @@ Host test
   Port 80
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-only.conf
+++ b/src/test/resources/fixtures/outputs/replace-only.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/replace-start.conf
+++ b/src/test/resources/fixtures/outputs/replace-start.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/url.conf
+++ b/src/test/resources/fixtures/outputs/url.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid?foo=bar&baz=qux ssh --stdio --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid?foo=bar&baz=qux ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/resources/fixtures/outputs/wildcard.conf
+++ b/src/test/resources/fixtures/outputs/wildcard.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox-test.coder.invalid--*
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --ssh-host-prefix coder-jetbrains-toolbox-test.coder.invalid-- %h
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --ssh-host-prefix coder-jetbrains-toolbox-test.coder.invalid-- %h
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null


### PR DESCRIPTION
Under the "Additional environment information". Unfortunately it was not possible any other way. The description property is modifiable however Toolbox renders the description label only as long as the SSH connection is not established. As soon as an ssh connection is running the description label is used as mechanism to notify users about available IDE updates.

It also appears that we can't have any other extra tab, other than "Tools", "Projects" and "Settings". There is a secondary information attribute API, but it is not usable to show recurring metrics info because it can only be
configured once, it is not a mutable field.

The best effort was to add the information in the Settings page, and it is worth highlighting that the metrics are only refreshed when user either:
- switches between tabs
- expands/collapses the "Additional environment information" section.

There is no programmatic mechanism to notify the information in the Settings page that latency changed.

The network metrics are loaded from the pid files created by the ssh command. Toolbox spawns a native process running the SSH client. The ssh client then spawns another process which is associated to the coder proxy command. SSH network metrics are saved into json files with the name equal to the pid of the ssh command (not to be confused with the proxy command's name). 

- resolves #100 
- resolves #101 