### PR TITLE
fix: open web terminal action is no longer displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - render network status in the Settings tab, under `Additional environment information` section.
 - quick action for creating new workspaces from the web dashboard.
 
+### Fixed
+
+- `Open web terminal` action is no longer displayed when the workspace is stopped.
+
 ## 0.2.1 - 2025-05-05
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.2.1
+version=0.2.2
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -70,29 +70,32 @@ class CoderRemoteEnvironment(
     fun asPairOfWorkspaceAndAgent(): Pair<Workspace, WorkspaceAgent> = Pair(workspace, agent)
 
     private fun getAvailableActions(): List<ActionDescription> {
-        val actions = mutableListOf(
-            Action(context.i18n.ptrl("Open web terminal")) {
+        val actions = mutableListOf<Action>()
+        if (wsRawStatus.canStop()) {
+            actions.add(Action(context.i18n.ptrl("Open web terminal")) {
                 context.cs.launch {
                     BrowserUtil.browse(client.url.withPath("/${workspace.ownerName}/$name/terminal").toString()) {
                         context.ui.showErrorInfoPopup(it)
                     }
                 }
-            },
+            })
+        }
+        actions.add(
             Action(context.i18n.ptrl("Open in dashboard")) {
                 context.cs.launch {
                     BrowserUtil.browse(client.url.withPath("/@${workspace.ownerName}/${workspace.name}").toString()) {
                         context.ui.showErrorInfoPopup(it)
                     }
                 }
-            },
-
-            Action(context.i18n.ptrl("View template")) {
-                context.cs.launch {
-                    BrowserUtil.browse(client.url.withPath("/templates/${workspace.templateName}").toString()) {
-                        context.ui.showErrorInfoPopup(it)
-                    }
-                }
             })
+
+        actions.add(Action(context.i18n.ptrl("View template")) {
+            context.cs.launch {
+                BrowserUtil.browse(client.url.withPath("/templates/${workspace.templateName}").toString()) {
+                    context.ui.showErrorInfoPopup(it)
+                }
+            }
+        })
 
         if (wsRawStatus.canStart()) {
             if (workspace.outdated) {


### PR DESCRIPTION
when the workspace is stopped. This action will be available only when the workspace is up and running (even when it is running with errors)
