### PR TITLE
fix: open URLs on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - `Open web terminal` action is no longer displayed when the workspace is stopped.
+- URL links can now be opened in Windows
 
 ## 0.2.1 - 2025-05-05
 

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -1,6 +1,6 @@
 package com.coder.toolbox
 
-import com.coder.toolbox.browser.BrowserUtil
+import com.coder.toolbox.browser.browse
 import com.coder.toolbox.cli.CoderCLIManager
 import com.coder.toolbox.cli.SshCommandProcessHandle
 import com.coder.toolbox.models.WorkspaceAndAgentStatus
@@ -74,7 +74,7 @@ class CoderRemoteEnvironment(
         if (wsRawStatus.canStop()) {
             actions.add(Action(context.i18n.ptrl("Open web terminal")) {
                 context.cs.launch {
-                    BrowserUtil.browse(client.url.withPath("/${workspace.ownerName}/$name/terminal").toString()) {
+                    context.desktop.browse(client.url.withPath("/${workspace.ownerName}/$name/terminal").toString()) {
                         context.ui.showErrorInfoPopup(it)
                     }
                 }
@@ -83,7 +83,9 @@ class CoderRemoteEnvironment(
         actions.add(
             Action(context.i18n.ptrl("Open in dashboard")) {
                 context.cs.launch {
-                    BrowserUtil.browse(client.url.withPath("/@${workspace.ownerName}/${workspace.name}").toString()) {
+                    context.desktop.browse(
+                        client.url.withPath("/@${workspace.ownerName}/${workspace.name}").toString()
+                    ) {
                         context.ui.showErrorInfoPopup(it)
                     }
                 }
@@ -91,7 +93,7 @@ class CoderRemoteEnvironment(
 
         actions.add(Action(context.i18n.ptrl("View template")) {
             context.cs.launch {
-                BrowserUtil.browse(client.url.withPath("/templates/${workspace.templateName}").toString()) {
+                context.desktop.browse(client.url.withPath("/templates/${workspace.templateName}").toString()) {
                     context.ui.showErrorInfoPopup(it)
                 }
             }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -1,6 +1,6 @@
 package com.coder.toolbox
 
-import com.coder.toolbox.browser.BrowserUtil
+import com.coder.toolbox.browser.browse
 import com.coder.toolbox.cli.CoderCLIManager
 import com.coder.toolbox.sdk.CoderRestClient
 import com.coder.toolbox.sdk.v2.models.WorkspaceStatus
@@ -190,7 +190,7 @@ class CoderRemoteProvider(
         listOf(
             Action(context.i18n.ptrl("Create workspace")) {
                 context.cs.launch {
-                    BrowserUtil.browse(client?.url?.withPath("/templates").toString()) {
+                    context.desktop.browse(client?.url?.withPath("/templates").toString()) {
                         context.ui.showErrorInfoPopup(it)
                     }
                 }

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
@@ -5,6 +5,7 @@ import com.coder.toolbox.store.CoderSecretsStore
 import com.coder.toolbox.store.CoderSettingsStore
 import com.coder.toolbox.util.toURL
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
+import com.jetbrains.toolbox.api.core.os.LocalDesktopManager
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
 import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
@@ -18,6 +19,7 @@ data class CoderToolboxContext(
     val envPageManager: EnvironmentUiPageManager,
     val envStateColorPalette: EnvironmentStateColorPalette,
     val ideOrchestrator: ClientHelper,
+    val desktop: LocalDesktopManager,
     val cs: CoroutineScope,
     val logger: Logger,
     val i18n: LocalizableStringFactory,
@@ -62,5 +64,4 @@ data class CoderToolboxContext(
             } else null
         }
     }
-
 }

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxExtension.kt
@@ -8,6 +8,7 @@ import com.jetbrains.toolbox.api.core.PluginSettingsStore
 import com.jetbrains.toolbox.api.core.ServiceLocator
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
 import com.jetbrains.toolbox.api.core.getService
+import com.jetbrains.toolbox.api.core.os.LocalDesktopManager
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.RemoteDevExtension
 import com.jetbrains.toolbox.api.remoteDev.RemoteProvider
@@ -31,6 +32,7 @@ class CoderToolboxExtension : RemoteDevExtension {
                 serviceLocator.getService<EnvironmentUiPageManager>(),
                 serviceLocator.getService<EnvironmentStateColorPalette>(),
                 serviceLocator.getService<ClientHelper>(),
+                serviceLocator.getService<LocalDesktopManager>(),
                 serviceLocator.getService<CoroutineScope>(),
                 serviceLocator.getService<Logger>(),
                 serviceLocator.getService<LocalizableStringFactory>(),

--- a/src/main/kotlin/com/coder/toolbox/util/Dialogs.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/Dialogs.kt
@@ -1,7 +1,7 @@
 package com.coder.toolbox.util
 
 import com.coder.toolbox.CoderToolboxContext
-import com.coder.toolbox.browser.BrowserUtil
+import com.coder.toolbox.browser.browse
 import com.jetbrains.toolbox.api.localization.LocalizableString
 import com.jetbrains.toolbox.api.ui.components.TextType
 import java.net.URL
@@ -23,12 +23,7 @@ class DialogUi(private val context: CoderToolboxContext) {
         placeholder: LocalizableString? = null,
     ): String? {
         return context.ui.showTextInputPopup(
-            title,
-            description,
-            placeholder,
-            TextType.General,
-            context.i18n.ptrl("OK"),
-            context.i18n.ptrl("Cancel")
+            title, description, placeholder, TextType.General, context.i18n.ptrl("OK"), context.i18n.ptrl("Cancel")
         )
     }
 
@@ -38,17 +33,12 @@ class DialogUi(private val context: CoderToolboxContext) {
         placeholder: LocalizableString? = null,
     ): String? {
         return context.ui.showTextInputPopup(
-            title,
-            description,
-            placeholder,
-            TextType.Password,
-            context.i18n.ptrl("OK"),
-            context.i18n.ptrl("Cancel")
+            title, description, placeholder, TextType.Password, context.i18n.ptrl("OK"), context.i18n.ptrl("Cancel")
         )
     }
 
     private suspend fun openUrl(url: URL) {
-        BrowserUtil.browse(url.toString()) {
+        context.desktop.browse(url.toString()) {
             context.ui.showErrorInfoPopup(it)
         }
     }

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -31,6 +31,7 @@ import com.coder.toolbox.util.pluginTestSettingsStore
 import com.coder.toolbox.util.sha1
 import com.coder.toolbox.util.toURL
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
+import com.jetbrains.toolbox.api.core.os.LocalDesktopManager
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
 import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
@@ -66,6 +67,7 @@ internal class CoderCLIManagerTest {
         mockk<EnvironmentUiPageManager>(),
         mockk<EnvironmentStateColorPalette>(),
         mockk<ClientHelper>(),
+        mockk<LocalDesktopManager>(),
         mockk<CoroutineScope>(),
         mockk<Logger>(relaxed = true),
         mockk<LocalizableStringFactory>(),

--- a/src/test/kotlin/com/coder/toolbox/sdk/CoderRestClientTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/sdk/CoderRestClientTest.kt
@@ -21,6 +21,7 @@ import com.coder.toolbox.store.TLS_CA_PATH
 import com.coder.toolbox.util.pluginTestSettingsStore
 import com.coder.toolbox.util.sslContextFromPEMs
 import com.jetbrains.toolbox.api.core.diagnostics.Logger
+import com.jetbrains.toolbox.api.core.os.LocalDesktopManager
 import com.jetbrains.toolbox.api.localization.LocalizableStringFactory
 import com.jetbrains.toolbox.api.remoteDev.connection.ClientHelper
 import com.jetbrains.toolbox.api.remoteDev.connection.ToolboxProxySettings
@@ -102,6 +103,7 @@ class CoderRestClientTest {
         mockk<EnvironmentUiPageManager>(),
         mockk<EnvironmentStateColorPalette>(),
         mockk<ClientHelper>(),
+        mockk<LocalDesktopManager>(),
         mockk<CoroutineScope>(),
         mockk<Logger>(relaxed = true),
         mockk<LocalizableStringFactory>(),


### PR DESCRIPTION
The URLs on Windows failed to be opened because the cmd executed via ProcessExecutor was not correctly constructed. We were calling `exec("cmd", "start \"$url\"")` but in Windows `/c` is also needed to the `cmd`.

We originally used native commands to open URLs because Toolbox didn’t support it. Now that LocalDesktopManager provides an API for launching the browser, we no longer need to fix the command-line logic — we can just use the Toolbox API instead.