### PR TITLE
impl: workspace status reporting (color and icons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- improved workspace status reporting (icon and colors) when it is stopping, deleting, stopped or when we are
+  establishing the SSH connection.
+
 ## 0.2.2 - 2025-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- improved workspace status reporting (icon and colors) when it is stopping, deleting, stopped or when we are
+- improved workspace status reporting (icon and colors) when it is failed, stopping, deleting, stopped or when we are
   establishing the SSH connection.
 
 ## 0.2.2 - 2025-05-21

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -157,6 +157,11 @@ class CoderRemoteEnvironment(
 
     override fun beforeConnection() {
         context.logger.info("Connecting to $id...")
+        context.cs.launch {
+            state.update {
+                wsRawStatus.toSshConnectingEnvState(context)
+            }
+        }
         isConnected.update { true }
         pollJob = pollNetworkMetrics()
     }

--- a/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/toolbox/models/WorkspaceAndAgentStatus.kt
@@ -72,19 +72,21 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
     }
 
     private fun getStateColor(context: CoderToolboxContext): StateColor {
-        return if (ready()) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Active)
+        return if (this == FAILED) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.FailedToStart)
+        else if (this == DELETING) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Deleting)
+        else if (this == DELETED) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Deleted)
+        else if (ready()) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Active)
         else if (unhealthy()) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Unhealthy)
         else if (canStart() || this == STOPPING) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Hibernating)
         else if (pending()) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Activating)
-        else if (this == DELETING) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Deleting)
-        else if (this == DELETED) context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Deleted)
         else context.envStateColorPalette.getColor(StandardRemoteEnvironmentState.Unreachable)
     }
 
     private fun getStateIcon(): EnvironmentStateIcons {
-        return if (ready() || unhealthy()) EnvironmentStateIcons.Active
-        else if (canStart()) EnvironmentStateIcons.Offline
+        return if (this == FAILED) EnvironmentStateIcons.Error
         else if (pending() || this == DELETING || this == DELETED || this == STOPPING) CircularSpinner
+        else if (ready() || unhealthy()) EnvironmentStateIcons.Active
+        else if (canStart()) EnvironmentStateIcons.Offline
         else EnvironmentStateIcons.NoIcon
     }
 


### PR DESCRIPTION
There were a couple of discrepancies in the status reporting especially around icons and colors:
- offline workspaces are marked by a new "offline" icon and a gray color (instead of a half pie icon with a red color)
- stopping state now has a gray progress spinner
- same for deleting state which previously used the offline icon instead of the spinner.
- failed workspaces used to render a gray offline icon instead of a red warning (exclamation mark) sign.
- there was no progress while establishing the SSH connection. Now we have a "SSHing" label with a circular progress bar while connecting to the SSH.