### PR TITLE
fix: url refresh after switching deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - improved workspace status reporting (icon and colors) when it is failed, stopping, deleting, stopped or when we are
   establishing the SSH connection.
 
-## 0.2.2 - 2025-05-21
+### Fixed
 
-### Added
+- url on the main page is now refreshed when switching between multiple deployments (via logout/login or URI handling)
+
+## 0.2.2 - 2025-05-21
 
 - render network status in the Settings tab, under `Additional environment information` section.
 - quick action for creating new workspaces from the web dashboard.

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -9,6 +9,7 @@ import com.coder.toolbox.util.DialogUi
 import com.coder.toolbox.util.withPath
 import com.coder.toolbox.views.Action
 import com.coder.toolbox.views.AuthWizardPage
+import com.coder.toolbox.views.CoderPage
 import com.coder.toolbox.views.CoderSettingsPage
 import com.coder.toolbox.views.NewEnvironmentPage
 import com.coder.toolbox.views.state.AuthWizardState
@@ -340,7 +341,9 @@ class CoderRemoteProvider(
         this.client = client
         pollJob?.cancel()
         environments.showLoadingMessage()
+        coderHeaderPage = NewEnvironmentPage(context, context.i18n.pnotr(client.url.toString()))
         pollJob = poll(client, cli)
+        context.ui.showUiPage(CoderPage.emptyPage(context))
         goToEnvironmentsPage()
     }
 

--- a/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
@@ -53,6 +53,10 @@ abstract class CoderPage(
             )
         }
     }
+
+    companion object {
+        fun emptyPage(ctx: CoderToolboxContext): UiPage = UiPage(ctx.i18n.pnotr(""))
+    }
 }
 
 /**


### PR DESCRIPTION
The main env header page API is quite limiting, in the sense that the title is never allowed to change. Today we display the Coder URL as the title. However, if the user switches between two deployments via log out and then log in, the URL is never refreshed, leading to a confusing UI (URL is old, while workspaces are from the new deployment)

JetBrains suggested a workaround in https://youtrack.jetbrains.com/issue/TBX-14421/ by creating a new env page instance with the updated title after each deployment switch. In which case Toolbox redraws the main screen when page state changes.
I tested the workaround and indeed it works but with a caveat. The new env page is refreshed only when Toolbox window page is made visible or when navigating from main env page to a single env page and then back to the main page. For some reason, if we call `envPageManager.showPluginEnvironmentsPage()`` from the authentication page displayed in `getOverrideUiPage() it doesn't trigger the new env refresh giving the false impression that the URL won't change. In fact this was the reason why I missed this workaround in previously.

It is interesting that if I first navigate to a blank page - `toolboxUi.showUiPage(emptyPage)` - and then immediately call `envPageManager.showPluginEnvironmentsPage()`, doing this rapid sequence seems to do the trick without any visible artifacts (it happens so fast that we can't see the blank page being rendered)

- resolves #66