### PR TITLE
fix: Stop action should be available when workspace is out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `Stop` action is now available for running workspaces that have an out of date template.
+
 ## 0.3.0 - 2025-06-10
 
 ### Added

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -126,16 +126,15 @@ class CoderRemoteEnvironment(
                         update(workspace.copy(latestBuild = build), agent)
                     }
                 })
-            } else {
-                actions.add(Action(context.i18n.ptrl("Stop")) {
-                    context.cs.launch {
-                        tryStopSshConnection()
-
-                        val build = client.stopWorkspace(workspace)
-                        update(workspace.copy(latestBuild = build), agent)
-                    }
-                })
             }
+            actions.add(Action(context.i18n.ptrl("Stop")) {
+                context.cs.launch {
+                    tryStopSshConnection()
+
+                    val build = client.stopWorkspace(workspace)
+                    update(workspace.copy(latestBuild = build), agent)
+                }
+            })
         }
         return actions
     }


### PR DESCRIPTION
Similarly to the web dashboard, `Stop` should be available alongside `Update and restart` action when a workspace is running but with a template out of date.