### PR TITLE
fix: install the build number if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Stop` action is now available for running workspaces that have an out of date template.
 - outdated and stopped workspaces are now updated and started when handling URI
 - show errors when the Toolbox is visible again after being minimized.
+- URI handling now installs the exact build number if it is available for the workspace.
 
 ## 0.3.0 - 2025-06-10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.3.0
+version=0.3.1
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -380,8 +380,8 @@ open class CoderProtocolHandler(
             return null
         }
 
-        val matchingBuildNumber = availableVersions.firstOrNull { it.contains(buildNumber) } != null
-        if (!matchingBuildNumber) {
+        val buildNumberIsNotAvailable = availableVersions.firstOrNull { it.contains(buildNumber) } == null
+        if (buildNumberIsNotAvailable) {
             val selectedIde = availableVersions.maxOf { it }
             context.logAndShowInfo(
                 "$productCode-$buildNumber not available",
@@ -389,7 +389,7 @@ open class CoderProtocolHandler(
             )
             return selectedIde
         }
-        return null
+        return "$productCode-$buildNumber"
     }
 
     private fun installJBClient(selectedIde: String, environmentId: String): Job = context.cs.launch {


### PR DESCRIPTION
This PR fixes an issue with URI handling which was not installing the exact same version requested by the user if the version was available for install on the workspace.