### PR TITLE
fix: class cast exception when handling Failed verification result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- fix class cast exception during signature verification
+
 ## 0.5.1 - 2025-07-21
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.5.1
+version=0.5.2
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -277,8 +277,8 @@ class CoderCLIManager(
             }
 
             else -> {
-                UnsignedBinaryExecutionDeniedException((result as Failed).error.message)
-                val failure = result as DownloadResult.Failed
+                val failure = result as Failed
+                UnsignedBinaryExecutionDeniedException(result.error.message)
                 context.logger.error(failure.error, "Failed to verify signature for ${cliResult.dst}")
             }
         }


### PR DESCRIPTION
Verification result was improperly cast to download result when signature verification failed to run.
I discovered this issue while porting the signature verifications to Coder Gateway plugin.