### PR TITLE
impl: enhanced workflow for network disruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- improved workflow when network connection is flaky
+
 ## 0.5.2 - 2025-07-22
 
 ### Fixed

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -166,17 +166,17 @@ class CoderRemoteProvider(
                     context.logger.error(ex, "workspace polling error encountered, trying to auto-login")
                     if (ex is APIResponseException && ex.isTokenExpired) {
                         WorkspaceConnectionManager.shouldEstablishWorkspaceConnections = true
+                        close()
+                        // force auto-login
+                        firstRun = true
+                        context.envPageManager.showPluginEnvironmentsPage()
+                        break
                     }
-                    close()
-                    // force auto-login
-                    firstRun = true
-                    context.envPageManager.showPluginEnvironmentsPage()
-                    break
                 }
             }
 
             // TODO: Listening on a web socket might be better?
-            select<Unit> {
+            select {
                 onTimeout(POLL_INTERVAL) {
                     context.logger.trace("workspace poller waked up by the $POLL_INTERVAL timeout")
                 }

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -146,6 +146,11 @@ interface ReadOnlyCoderSettings {
      * Return the URL and token from the config, if they exist.
      */
     fun readConfig(dir: Path): Pair<String?, String?>
+
+    /**
+     * Returns whether the SSH connection should be automatically established.
+     */
+    fun shouldAutoConnect(workspaceId: String): Boolean
 }
 
 /**

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -142,6 +142,10 @@ class CoderSettingsStore(
                 }
     }
 
+    override fun shouldAutoConnect(workspaceId: String): Boolean {
+        return store["$SSH_AUTO_CONNECT_PREFIX$workspaceId"]?.toBooleanStrictOrNull() ?: false
+    }
+
     // a readonly cast
     fun readOnly(): ReadOnlyCoderSettings = this
 
@@ -211,6 +215,10 @@ class CoderSettingsStore(
 
     fun updateSshConfigOptions(options: String) {
         store[SSH_CONFIG_OPTIONS] = options
+    }
+
+    fun updateAutoConnect(workspaceId: String, autoConnect: Boolean) {
+        store["$SSH_AUTO_CONNECT_PREFIX$workspaceId"] = autoConnect.toString()
     }
 
     private fun getDefaultGlobalDataDir(): Path {

--- a/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
@@ -42,3 +42,5 @@ internal const val SSH_CONFIG_OPTIONS = "sshConfigOptions"
 
 internal const val NETWORK_INFO_DIR = "networkInfoDir"
 
+internal const val SSH_AUTO_CONNECT_PREFIX = "ssh_auto_connect_"
+


### PR DESCRIPTION
 Currently, when the network connection drops, the Coder TBX plugin resets itself, redirects users to the authentication page, and terminates active SSH sessions to remote IDEs. This disrupts the user experience, forcing users to manually reconnect once the network is restored. Additionally, since the SSH session to the remote IDE is lost, the JBClient is unable to re-establish a connection with the remote backend.
    
This PR aims to improve that experience by adopting a behavior similar to the SSH plugin. Instead of clearing the list of workspaces or dropping existing SSH sessions during a network outage, we retain them. Once the network is restored, the plugin will automatically reinitialize the HTTP client and regenerate the SSH configuration—only if the number of workspaces has changed during the disconnection—without requiring user intervention.

Additionally we also add support for remembering SSH connections that were not manually disconnected by the user. This allows the plugin to automatically restore those connections on the next startup enabling remote IDEs that remained open to reconnect once the SSH link is re-established.
