### PR TITLE
impl: relax json syntax rules for deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- the http client has relaxed syntax rules when deserializing JSON responses
+
 ## 0.6.0 - 2025-07-25
 
 ### Changed

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -74,10 +74,10 @@ open class CoderRestClient(
         var builder = OkHttpClient.Builder()
 
         if (context.proxySettings.getProxy() != null) {
-            context.logger.debug("proxy: ${context.proxySettings.getProxy()}")
+            context.logger.info("proxy: ${context.proxySettings.getProxy()}")
             builder.proxy(context.proxySettings.getProxy())
         } else if (context.proxySettings.getProxySelector() != null) {
-            context.logger.debug("proxy selector: ${context.proxySettings.getProxySelector()}")
+            context.logger.info("proxy selector: ${context.proxySettings.getProxySelector()}")
             builder.proxySelector(context.proxySettings.getProxySelector()!!)
         }
 
@@ -133,7 +133,7 @@ open class CoderRestClient(
 
         retroRestClient =
             Retrofit.Builder().baseUrl(url.toString()).client(httpClient)
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
                 .build().create(CoderV2RestFacade::class.java)
     }
 


### PR DESCRIPTION
For some clients, workspace polling fails due to the following error:

```
com.squareup.moshi.JsonEncodingException: Use JsonReader.setLenient(true) to accept malformed JSON at path $
```

I haven’t been able to reproduce this issue, even using the same version deployed at the client (2.20.2). This change is an attempt to relax the JSON parsing rules by enabling lenient mode, in the hope that it will resolve the issue on the client side.