### PR TITLE
impl: add support for disabling CLI signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- support for skipping CLI signature verification
+
 ### Changed
 
 - URL validation is stricter in the connection screen and URI protocol handler

--- a/JETBRAINS_COMPLIANCE.md
+++ b/JETBRAINS_COMPLIANCE.md
@@ -39,8 +39,6 @@ This configuration includes JetBrains-specific rules that check for:
 - **ForbiddenImport**: Detects potentially bundled libraries
 - **Standard code quality rules**: Complexity, naming, performance, etc.
 
-
-
 ## CI/CD Integration
 
 The GitHub Actions workflow `.github/workflows/jetbrains-compliance.yml` runs compliance checks on every PR and push.
@@ -54,8 +52,6 @@ The GitHub Actions workflow `.github/workflows/jetbrains-compliance.yml` runs co
 # View HTML report
 open build/reports/detekt/detekt.html
 ```
-
-
 
 ## Understanding Results
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,69 @@ If `ide_product_code` and `ide_build_number` is missing, Toolbox will only open 
 page. Coder Toolbox will attempt to start the workspace if it’s not already running; however, for the most reliable
 experience, it’s recommended to ensure the workspace is running prior to initiating the connection.
 
+## GPG Signature Verification
+
+The Coder Toolbox plugin starting with version *0.5.0* implements a comprehensive GPG signature verification system to
+ensure the authenticity and integrity of downloaded Coder CLI binaries. This security feature helps protect users from
+running potentially malicious or tampered binaries.
+
+### How It Works
+
+1. **Binary Download**: When connecting to a Coder deployment, the plugin downloads the appropriate Coder CLI binary for
+   the user's operating system and architecture from the deployment's `/bin/` endpoint.
+
+2. **Signature Download**: After downloading the binary, the plugin attempts to download the corresponding `.asc`
+   signature file from the same location. The signature file is named according to the binary (e.g.,
+   `coder-linux-amd64.asc` for `coder-linux-amd64`).
+
+3. **Fallback Signature Sources**: If the signature is not available from the deployment, the plugin can optionally fall
+   back to downloading signatures from `releases.coder.com`. This is controlled by the `fallbackOnCoderForSignatures`
+   setting.
+
+4. **GPG Verification**: The plugin uses the BouncyCastle library to verify the detached GPG signature against the
+   downloaded binary using Coder's trusted public key.
+
+5. **User Interaction**: If signature verification fails or signatures are unavailable, the plugin presents security
+   warnings to users, allowing them to accept the risk and continue or abort the operation.
+
+### Verification Process
+
+The verification process involves several components:
+
+- **`GPGVerifier`**: Handles the core GPG signature verification logic using BouncyCastle
+- **`VerificationResult`**: Represents the outcome of verification (Valid, Invalid, Failed, SignatureNotFound)
+- **`CoderDownloadService`**: Manages downloading both binaries and their signatures
+- **`CoderCLIManager`**: Orchestrates the download and verification workflow
+
+### Configuration Options
+
+Users can control signature verification behavior through plugin settings:
+
+- **`disableSignatureVerification`**: When enabled, skips all signature verification. This is useful for clients running
+  custom CLI builds, or customers with old deployment versions that don't have a signature published on
+  `releases.coder.com`.
+- **`fallbackOnCoderForSignatures`**: When enabled, allows downloading signatures from `releases.coder.com` if not
+  available from the deployment.
+
+### Security Considerations
+
+- The plugin embeds Coder's trusted public key in the plugin resources
+- Verification uses detached signatures, which are more secure than attached signatures
+- Users are warned about security risks when verification fails
+- The system gracefully handles cases where signatures are unavailable
+- All verification failures are logged for debugging purposes
+
+### Error Handling
+
+The system handles various failure scenarios:
+
+- **Missing signatures**: Prompts user to accept risk or abort
+- **Invalid signatures**: Warns user about potential tampering and prompts user to accept risk or abort
+- **Verification failures**: Prompts user to accept risk or abort
+
+This signature verification system ensures that users can trust the Coder CLI binaries they download through the plugin,
+protecting against supply chain attacks and ensuring binary integrity.
+
 ## Configuring and Testing workspace polling with HTTP & SOCKS5 Proxy
 
 This section explains how to set up a local proxy and verify that

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.0
+version=0.6.1
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -181,6 +181,12 @@ class CoderCLIManager(
                 }
             }
 
+            if (context.settingsStore.disableSignatureVerification) {
+                downloader.commit()
+                context.logger.info("Skipping over CLI signature verification, it is disabled by the user")
+                return true
+            }
+
             var signatureResult = withContext(Dispatchers.IO) {
                 downloader.downloadSignature(showTextProgress)
             }

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -29,7 +29,12 @@ interface ReadOnlyCoderSettings {
     val binaryDirectory: String?
 
     /**
-     * Controls whether we fall back release.coder.com
+     * Controls whether we verify the cli signature
+     */
+    val disableSignatureVerification: Boolean
+
+    /**
+     * Controls whether we fall back on release.coder.com for signatures if signature validation is enabled
      */
     val fallbackOnCoderForSignatures: SignatureFallbackStrategy
 

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -38,6 +38,8 @@ class CoderSettingsStore(
     override val defaultURL: String get() = store[DEFAULT_URL] ?: "https://dev.coder.com"
     override val binarySource: String? get() = store[BINARY_SOURCE]
     override val binaryDirectory: String? get() = store[BINARY_DIRECTORY]
+    override val disableSignatureVerification: Boolean
+        get() = store[DISABLE_SIGNATURE_VALIDATION]?.toBooleanStrictOrNull() ?: false
     override val fallbackOnCoderForSignatures: SignatureFallbackStrategy
         get() = SignatureFallbackStrategy.fromValue(store[FALLBACK_ON_CODER_FOR_SIGNATURES])
     override val defaultCliBinaryNameByOsAndArch: String get() = getCoderCLIForOS(getOS(), getArch())
@@ -164,6 +166,10 @@ class CoderSettingsStore(
 
     fun updateEnableDownloads(shouldEnableDownloads: Boolean) {
         store[ENABLE_DOWNLOADS] = shouldEnableDownloads.toString()
+    }
+
+    fun updateDisableSignatureVerification(shouldDisableSignatureVerification: Boolean) {
+        store[DISABLE_SIGNATURE_VALIDATION] = shouldDisableSignatureVerification.toString()
     }
 
     fun updateSignatureFallbackStrategy(fallback: Boolean) {

--- a/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
@@ -10,6 +10,8 @@ internal const val BINARY_SOURCE = "binarySource"
 
 internal const val BINARY_DIRECTORY = "binaryDirectory"
 
+internal const val DISABLE_SIGNATURE_VALIDATION = "disableSignatureValidation"
+
 internal const val FALLBACK_ON_CODER_FOR_SIGNATURES = "signatureFallbackStrategy"
 
 internal const val BINARY_NAME = "binaryName"

--- a/src/main/kotlin/com/coder/toolbox/views/DeploymentUrlStep.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/DeploymentUrlStep.kt
@@ -1,7 +1,6 @@
 package com.coder.toolbox.views
 
 import com.coder.toolbox.CoderToolboxContext
-import com.coder.toolbox.settings.SignatureFallbackStrategy
 import com.coder.toolbox.util.WebUrlValidationResult.Invalid
 import com.coder.toolbox.util.toURL
 import com.coder.toolbox.util.validateStrictWebUrl
@@ -41,7 +40,7 @@ class DeploymentUrlStep(
 
     override val panel: RowGroup
         get() {
-            if (context.settingsStore.fallbackOnCoderForSignatures == SignatureFallbackStrategy.NOT_CONFIGURED) {
+            if (!context.settingsStore.disableSignatureVerification) {
                 return RowGroup(
                     RowGroup.RowField(urlField),
                     RowGroup.RowField(emptyLine),

--- a/src/main/resources/localization/defaultMessages.po
+++ b/src/main/resources/localization/defaultMessages.po
@@ -165,3 +165,6 @@ msgstr ""
 
 msgid "Run anyway"
 msgstr ""
+
+msgid "Disable Coder CLI signature verification"
+msgstr ""


### PR DESCRIPTION
This PR implements a new configurable option to allow users to disable GPG signature verification for downloaded Coder CLI binaries. This feature provides flexibility for environments where signature verification may not be required or where fallback signature sources are not accessible.

A new option `disableSignatureVerification` is now available only from the Settings page, with no quick shortcut in the main page to discourage users from quickly disabling this option. The `fallbackOnCoderForSignatures` is hidden/not available for configuration once signature verification is disabled.
Additionally a rough draft for developer facing documentation regarding CLI signature verification was added.

This PR is a port of https://github.com/coder/jetbrains-coder/pull/564 from Coder Gateway.