### PR TITLE
fix: enforce Content-Type to accept only binary responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- content-type is now enforced when downloading the CLI to accept only binary responses
+
 ## 0.6.1 - 2025-08-11
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.1
+version=0.6.2
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/cli/downloader/CoderDownloadService.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/downloader/CoderDownloadService.kt
@@ -51,6 +51,13 @@ class CoderDownloadService(
 
         return when (response.code()) {
             HTTP_OK -> {
+                val contentType = response.headers()["Content-Type"]?.lowercase()
+                if (contentType?.startsWith("application/octet-stream") != true) {
+                    throw ResponseException(
+                        "Invalid content type '$contentType' when downloading CLI from $remoteBinaryURL. Expected application/octet-stream.",
+                        response.code()
+                    )
+                }
                 context.logger.info("Downloading binary to temporary $cliTempDst")
                 response.saveToDisk(cliTempDst, showTextProgress, buildVersion)?.makeExecutable()
                 DownloadResult.Downloaded(remoteBinaryURL, cliTempDst)

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -137,6 +137,7 @@ internal class CoderCLIManagerTest {
             }
 
             val body = response.toByteArray()
+            exchange.responseHeaders["Content-Type"] = "application/octet-stream"
             exchange.sendResponseHeaders(code, if (code == HttpURLConnection.HTTP_OK) body.size.toLong() else -1)
             exchange.responseBody.write(body)
             exchange.close()
@@ -197,11 +198,11 @@ internal class CoderCLIManagerTest {
         val ccm = CoderCLIManager(
             context.copy(
                 settingsStore = CoderSettingsStore(
-                pluginTestSettingsStore(
-                    DATA_DIRECTORY to tmpdir.resolve("cli-dir-fail-to-write").toString(),
-                ),
-                Environment(),
-                context.logger
+                    pluginTestSettingsStore(
+                        DATA_DIRECTORY to tmpdir.resolve("cli-dir-fail-to-write").toString(),
+                    ),
+                    Environment(),
+                    context.logger
                 )
             ),
             url
@@ -307,11 +308,11 @@ internal class CoderCLIManagerTest {
         val ccm = CoderCLIManager(
             context.copy(
                 settingsStore = CoderSettingsStore(
-                pluginTestSettingsStore(
-                    DATA_DIRECTORY to tmpdir.resolve("does-not-exist").toString(),
-                ),
-                Environment(),
-                context.logger
+                    pluginTestSettingsStore(
+                        DATA_DIRECTORY to tmpdir.resolve("does-not-exist").toString(),
+                    ),
+                    Environment(),
+                    context.logger
                 )
             ),
             URL("https://foo")
@@ -329,12 +330,12 @@ internal class CoderCLIManagerTest {
         val ccm = CoderCLIManager(
             context.copy(
                 settingsStore = CoderSettingsStore(
-                pluginTestSettingsStore(
-                    FALLBACK_ON_CODER_FOR_SIGNATURES to "allow",
-                    DATA_DIRECTORY to tmpdir.resolve("overwrite-cli").toString(),
-                ),
-                Environment(),
-                context.logger
+                    pluginTestSettingsStore(
+                        FALLBACK_ON_CODER_FOR_SIGNATURES to "allow",
+                        DATA_DIRECTORY to tmpdir.resolve("overwrite-cli").toString(),
+                    ),
+                    Environment(),
+                    context.logger
                 )
             ),
             url


### PR DESCRIPTION
Add validation for CLI downloads that ensures the Content-Type header is indicating a binary stream (`application/octet-stream`), including common variants with parameters. This prevents saving unexpected HTML or other non-binary responses (e.g., from frontend dev servers on :8080) as binaries, improving reliability and providing clearer error feedback.