### PR TITLE
impl: poll workspaces when Toolbox screen becomes visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- workspaces status is now refresh every time Coder Toolbox becomes visible
+
 ## 0.6.2 - 2025-08-14
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.2
+version=0.6.3
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -177,17 +177,17 @@ class CoderRemoteProvider(
 
             select {
                 onTimeout(POLL_INTERVAL) {
-                    context.logger.trace("workspace poller waked up by the $POLL_INTERVAL timeout")
+                    context.logger.debug("workspace poller waked up by the $POLL_INTERVAL timeout")
                 }
                 triggerSshConfig.onReceive { shouldTrigger ->
                     if (shouldTrigger) {
-                        context.logger.trace("workspace poller waked up because it should reconfigure the ssh configurations")
+                        context.logger.debug("workspace poller waked up because it should reconfigure the ssh configurations")
                         cli.configSsh(lastEnvironments.map { it.asPairOfWorkspaceAndAgent() }.toSet())
                     }
                 }
                 triggerProviderVisible.onReceive { isCoderProviderVisible ->
                     if (isCoderProviderVisible) {
-                        context.logger.info("workspace poller waked up, Coder Toolbox is currently visible, fetching latest workspace statuses")
+                        context.logger.debug("workspace poller waked up, Coder Toolbox is currently visible, fetching latest workspace statuses")
                     }
                 }
             }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -187,7 +187,7 @@ class CoderRemoteProvider(
                 }
                 triggerProviderVisible.onReceive { isCoderProviderVisible ->
                     if (isCoderProviderVisible) {
-                        context.logger.debug("workspace poller waked up, Coder Toolbox is currently visible, fetching latest workspace statuses")
+                        context.logger.debug("workspace poller waked up by Coder Toolbox which is currently visible, fetching latest workspace statuses")
                     }
                 }
             }


### PR DESCRIPTION
Some users complained that Coder Toolbox has a noticeable delay in rendering the workspaces
status compared with the web Dashboard, even though they have the same polling frequency,
which is every 5 seconds.
However, the web Dashboard also reacts and when the tab receives focus from the user which
improves the experience. This PR tries to implement the same behavior, when Coder Toolbox
screen becomes visible the polling is triggered immediately which should result in a status update.