### PR TITLE
impl: report progress while handling URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- progress reporting while handling URIs
+
 ### Changed
 
 - workspaces status is now refresh every time Coder Toolbox becomes visible

--- a/src/main/kotlin/com/coder/toolbox/views/CoderCliSetupWizardPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/CoderCliSetupWizardPage.kt
@@ -4,8 +4,6 @@ import com.coder.toolbox.CoderToolboxContext
 import com.coder.toolbox.cli.CoderCLIManager
 import com.coder.toolbox.sdk.CoderRestClient
 import com.coder.toolbox.sdk.ex.APIResponseException
-import com.coder.toolbox.util.toURL
-import com.coder.toolbox.views.state.CoderCliSetupContext
 import com.coder.toolbox.views.state.CoderCliSetupWizardState
 import com.coder.toolbox.views.state.WizardStep
 import com.jetbrains.toolbox.api.remoteDev.ProviderVisibilityState
@@ -48,13 +46,6 @@ class CoderCliSetupWizardPage(
     override val actionButtons: MutableStateFlow<List<RunnableActionDescription>> = MutableStateFlow(emptyList())
 
     private val errorBuffer = mutableListOf<Throwable>()
-
-    init {
-        if (shouldAutoSetup.value) {
-            CoderCliSetupContext.url = context.secrets.lastDeploymentURL.toURL()
-            CoderCliSetupContext.token = context.secrets.lastToken
-        }
-    }
 
     override fun beforeShow() {
         displaySteps()

--- a/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/CoderPage.kt
@@ -1,6 +1,5 @@
 package com.coder.toolbox.views
 
-import com.coder.toolbox.CoderToolboxContext
 import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon
 import com.jetbrains.toolbox.api.core.ui.icons.SvgIcon.IconType
 import com.jetbrains.toolbox.api.localization.LocalizableString
@@ -42,12 +41,6 @@ abstract class CoderPage(
         )
     } else {
         SvgIcon(byteArrayOf(), type = IconType.Masked)
-    }
-
-    override val isBusyCreatingNewEnvironment: MutableStateFlow<Boolean> = MutableStateFlow(false)
-
-    companion object {
-        fun emptyPage(ctx: CoderToolboxContext): UiPage = UiPage(ctx.i18n.pnotr(""))
     }
 }
 

--- a/src/test/kotlin/com/coder/toolbox/util/CoderProtocolHandlerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/util/CoderProtocolHandlerTest.kt
@@ -43,7 +43,9 @@ internal class CoderProtocolHandlerTest {
     private val protocolHandler = CoderProtocolHandler(
         context,
         DialogUi(context),
-        MutableStateFlow(false)
+        MutableStateFlow(false),
+        visibilityState,
+        isInitialized
     )
 
     private val agents =


### PR DESCRIPTION
Up until now there was no progress while downloading CLI, setting up the cli and the ssh config while handling URIs. This PR reworks the uri handler and the connection screen to be able to reuse the later part in the URI handler. This should improve the experience because the user is no longer left in the dark for a good couple of seconds.