### PR TITLE
fix: NPE during error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - improved diagnose support
 
+### Fixed
+
+- NPE during error reporting
+
 ## 0.6.3 - 2025-08-25
 
 ### Added

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -409,7 +409,6 @@ class CoderRemoteProvider(
         context.logger.info("Displaying ${client.url} in the UI")
         pollJob = poll(client, cli)
         context.logger.info("Workspace poll job created with reference $pollJob")
-        context.envPageManager.showPluginEnvironmentsPage()
     }
 
     private fun MutableStateFlow<LoadableState<List<CoderRemoteEnvironment>>>.showLoadingMessage() {

--- a/src/main/kotlin/com/coder/toolbox/views/ErrorReporter.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/ErrorReporter.kt
@@ -1,0 +1,73 @@
+package com.coder.toolbox.views
+
+import com.coder.toolbox.CoderToolboxContext
+import com.coder.toolbox.sdk.ex.APIResponseException
+import com.jetbrains.toolbox.api.remoteDev.ProviderVisibilityState
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+sealed class ErrorReporter {
+
+    /**
+     * Logs and show errors as popups.
+     */
+    abstract fun report(message: String, ex: Throwable)
+
+    /**
+     * Processes any buffered errors when the application becomes visible.
+     */
+    abstract fun flush()
+
+    companion object {
+        fun create(
+            context: CoderToolboxContext,
+            visibilityState: StateFlow<ProviderVisibilityState>,
+            callerClass: Class<*>
+        ): ErrorReporter = ErrorReporterImpl(context, visibilityState, callerClass)
+    }
+}
+
+private class ErrorReporterImpl(
+    private val context: CoderToolboxContext,
+    private val visibilityState: StateFlow<ProviderVisibilityState>,
+    private val callerClass: Class<*>
+) : ErrorReporter() {
+    private val errorBuffer = mutableListOf<Throwable>()
+
+    override fun report(message: String, ex: Throwable) {
+        context.logger.error(ex, "[${callerClass.simpleName}] $message")
+        if (!visibilityState.value.applicationVisible) {
+            context.logger.debug("Toolbox is not yet visible, scheduling error to be displayed later")
+            errorBuffer.add(ex)
+            return
+        }
+        showError(ex)
+    }
+
+    private fun showError(ex: Throwable) {
+        val textError = if (ex is APIResponseException) {
+            if (!ex.reason.isNullOrBlank()) {
+                ex.reason
+            } else ex.message
+        } else ex.message ?: ex.toString()
+        context.cs.launch {
+            context.ui.showSnackbar(
+                UUID.randomUUID().toString(),
+                context.i18n.ptrl("Error encountered while setting up Coder"),
+                context.i18n.pnotr(textError ?: ""),
+                context.i18n.ptrl("Dismiss")
+            )
+        }
+    }
+
+
+    override fun flush() {
+        if (errorBuffer.isNotEmpty() && visibilityState.value.applicationVisible) {
+            errorBuffer.forEach {
+                showError(it)
+            }
+            errorBuffer.clear()
+        }
+    }
+}


### PR DESCRIPTION
The try/catch block raised NPE in the `notify` if another exception was raised after the context containing the URL was reset - so that means an error in the onConnect handler. In addition, some of the reset steps were moved after onConnect to make sure they execute only if onConnect callback is successful.

Because of the fault in how the steps were arranged, the original exception was never logged instead a misleading NPE was treated by the coroutine's exception handler.