### PR TITLE
fix: relaxed Content-Type checks for CLI download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - NPE during error reporting
+- relaxed `Content-Type` checks while downloading the CLI
 
 ## 0.6.3 - 2025-08-25
 

--- a/src/main/kotlin/com/coder/toolbox/cli/downloader/CoderDownloadService.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/downloader/CoderDownloadService.kt
@@ -25,6 +25,18 @@ import java.util.zip.GZIPInputStream
 import kotlin.io.path.name
 import kotlin.io.path.notExists
 
+private val SUPPORTED_BIN_MIME_TYPES = listOf(
+    "application/octet-stream",
+    "application/exe",
+    "application/dos-exe",
+    "application/msdos-windows",
+    "application/x-exe",
+    "application/x-msdownload",
+    "application/x-winexe",
+    "application/x-msdos-program",
+    "application/x-msdos-executable",
+    "application/vnd.microsoft.portable-executable"
+)
 /**
  * Handles the download steps of Coder CLI
  */
@@ -52,7 +64,7 @@ class CoderDownloadService(
         return when (response.code()) {
             HTTP_OK -> {
                 val contentType = response.headers()["Content-Type"]?.lowercase()
-                if (contentType?.startsWith("application/octet-stream") != true) {
+                if (contentType !in SUPPORTED_BIN_MIME_TYPES) {
                     throw ResponseException(
                         "Invalid content type '$contentType' when downloading CLI from $remoteBinaryURL. Expected application/octet-stream.",
                         response.code()


### PR DESCRIPTION
This PR fixes download failure for Windows .exe binaries by relaxing strict Content-Type checks. Previously, the plugin only accepted application/octet-stream, causing failures when .exe files were served as application/x-msdos-executable by some servers.

- resolves #187