### PR TITLE
impl: store last used URL in Toolbox Settings Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- simplified storage for last used url and token
+
 ## 0.6.6 - 2025-09-24
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.6
+version=0.7.0
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -406,7 +406,6 @@ class CoderRemoteProvider(
         // Store the URL and token for use next time.
         context.settingsStore.updateLastUsedUrl(client.url)
         if (context.settingsStore.requireTokenAuth) {
-            context.secrets.lastToken = client.token ?: ""
             context.secrets.storeTokenFor(client.url, client.token ?: "")
             context.logger.info("Deployment URL and token were stored and will be available for automatic connection")
         } else {

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
@@ -42,12 +42,9 @@ data class CoderToolboxContext(
      */
     val deploymentUrl: URL
         get() {
-            if (!this.settingsStore.lastDeploymentURL.isNullOrBlank()) {
-                return this.settingsStore.lastDeploymentURL!!.toURL()
-            } else if (this.secrets.lastDeploymentURL.isNotBlank()) {
-                return this.secrets.lastDeploymentURL.toURL()
-            }
-            return this.settingsStore.defaultURL.toURL()
+            return settingsStore.lastDeploymentURL?.takeIf { it.isNotBlank() }?.toURL()
+                ?: secrets.lastDeploymentURL.takeIf { it.isNotBlank() }?.toURL()
+                ?: settingsStore.defaultURL.toURL()
         }
 
     suspend fun logAndShowError(title: String, error: String) {

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
@@ -36,14 +36,15 @@ data class CoderToolboxContext(
      *
      * In order of preference:
      *
-     * 1. Last used URL.
-     * 2. URL in settings.
-     * 3. CODER_URL.
-     * 4. URL in global cli config.
+     * 1. Last used URL from the settings.
+     * 2. Last used URL from the secrets store.
+     * 3. Default URL
      */
     val deploymentUrl: URL
         get() {
-            if (this.secrets.lastDeploymentURL.isNotBlank()) {
+            if (!this.settingsStore.lastDeploymentURL.isNullOrBlank()) {
+                return this.settingsStore.lastDeploymentURL!!.toURL()
+            } else if (this.secrets.lastDeploymentURL.isNotBlank()) {
                 return this.secrets.lastDeploymentURL.toURL()
             }
             return this.settingsStore.defaultURL.toURL()

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -8,6 +8,12 @@ import java.util.Locale.getDefault
  * Read-only interface for accessing Coder settings
  */
 interface ReadOnlyCoderSettings {
+
+    /**
+     * The last used deployment URL.
+     */
+    val lastDeploymentURL: String?
+
     /**
      * The default URL to show in the connection window.
      */

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
@@ -18,14 +18,11 @@ class CoderSecretsStore(private val store: PluginSecretStore) {
         }
     }
 
-    var lastDeploymentURL: String
+    val lastDeploymentURL: String
         get() = get("last-deployment-url")
-        set(value) = set("last-deployment-url", value)
     var lastToken: String
         get() = get("last-token")
         set(value) = set("last-token", value)
-    val canAutoLogin: Boolean
-        get() = lastDeploymentURL.isNotBlank() && lastToken.isNotBlank()
 
     fun tokenFor(url: URL): String? = store[url.host]
 

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
@@ -8,21 +8,7 @@ import java.net.URL
  * Provides Coder secrets backed by the secrets store service.
  */
 class CoderSecretsStore(private val store: PluginSecretStore) {
-    private fun get(key: String): String = store[key] ?: ""
-
-    private fun set(key: String, value: String) {
-        if (value.isBlank()) {
-            store.clear(key)
-        } else {
-            store[key] = value
-        }
-    }
-
-    val lastDeploymentURL: String
-        get() = get("last-deployment-url")
-    var lastToken: String
-        get() = get("last-token")
-        set(value) = set("last-token", value)
+    val lastDeploymentURL: String = store["last-deployment-url"] ?: ""
 
     fun tokenFor(url: URL): String? = store[url.host]
 

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSecretsStore.kt
@@ -8,6 +8,10 @@ import java.net.URL
  * Provides Coder secrets backed by the secrets store service.
  */
 class CoderSecretsStore(private val store: PluginSecretStore) {
+    @Deprecated(
+        message = "The URL is now stored the JSON backed settings store. Use CoderSettingsStore#lastDeploymentURL",
+        replaceWith = ReplaceWith("context.settingsStore.lastDeploymentURL")
+    )
     val lastDeploymentURL: String = store["last-deployment-url"] ?: ""
 
     fun tokenFor(url: URL): String? = store[url.host]

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -36,6 +36,7 @@ class CoderSettingsStore(
     ) : ReadOnlyTLSSettings
 
     // Properties implementation
+    override val lastDeploymentURL: String? get() = store[LAST_USED_URL]
     override val defaultURL: String get() = store[DEFAULT_URL] ?: "https://dev.coder.com"
     override val binarySource: String? get() = store[BINARY_SOURCE]
     override val binaryDirectory: String? get() = store[BINARY_DIRECTORY]
@@ -155,6 +156,10 @@ class CoderSettingsStore(
     fun readOnly(): ReadOnlyCoderSettings = this
 
     // Write operations
+    fun updateLastUsedUrl(url: URL) {
+        store[LAST_USED_URL] = url.toString()
+    }
+
     fun updateBinarySource(source: String) {
         store[BINARY_SOURCE] = source
     }

--- a/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
@@ -2,7 +2,7 @@ package com.coder.toolbox.store
 
 internal const val CODER_SSH_CONFIG_OPTIONS = "CODER_SSH_CONFIG_OPTIONS"
 
-internal const val CODER_URL = "CODER_URL"
+internal const val LAST_USED_URL = "lastDeploymentURL"
 
 internal const val DEFAULT_URL = "defaultURL"
 

--- a/src/main/kotlin/com/coder/toolbox/views/DeploymentUrlStep.kt
+++ b/src/main/kotlin/com/coder/toolbox/views/DeploymentUrlStep.kt
@@ -63,8 +63,8 @@ class DeploymentUrlStep(
         errorField.textState.update {
             context.i18n.pnotr("")
         }
-        urlField.textState.update {
-            context.secrets.lastDeploymentURL
+        urlField.contentState.update {
+            context.deploymentUrl.toString()
         }
 
         signatureFallbackStrategyField.checkedState.update {


### PR DESCRIPTION
Context: Toolbox can store key/value pairs in two places:
- a settings store which is backed by a clear text json file per each plugin
- native keystore for sensitive data

At the same time some of Coder's clients (ex: Netflix) would like to deploy at scale preconfigured settings for Toolbox. Most of the needed settings are part of json backed store except the last used URL.

This PR reworks the code around the last used URL/token and moves the URL in the json backed store, making it easy to configure. At the same time we still support the pair stored in the native keystore for backward compatibility reasons.