### PR TITLE
chore: downgrade plugin version to 0.7.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.7.3
+version=0.7.2
 group=com.coder.toolbox
 name=coder-toolbox


### PR DESCRIPTION
It was increased to 0.7.3 by mistake, 0.7.2 was not actually released.