### PR TITLE
impl: start the workspace via Coder CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - application name can now be displayed as the main title page instead of the URL
 
+### Changed
+
+- workspaces are now started with the help of the CLI
+
 ## 0.7.2 - 2025-11-03
 
 ### Changed

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -125,6 +125,7 @@ data class Features(
     val disableAutostart: Boolean = false,
     val reportWorkspaceUsage: Boolean = false,
     val wildcardSsh: Boolean = false,
+    val buildReason: Boolean = false,
 )
 
 /**
@@ -302,6 +303,25 @@ class CoderCLIManager(
             "--global-config",
             coderConfigPath.toString(),
         )
+    }
+
+    /**
+     * Start a workspace. Throws if the command execution fails.
+     */
+    fun startWorkspace(workspaceOwner: String, workspaceName: String, feats: Features = features): String {
+        val args = mutableListOf(
+            "--global-config",
+            coderConfigPath.toString(),
+            "start",
+            "--yes",
+            "$workspaceOwner/$workspaceName"
+        )
+
+        if (feats.buildReason) {
+            args.addAll(listOf("--reason", "jetbrains_connection"))
+        }
+
+        return exec(*args.toTypedArray())
     }
 
     /**
@@ -569,7 +589,8 @@ class CoderCLIManager(
                 Features(
                     disableAutostart = version >= SemVer(2, 5, 0),
                     reportWorkspaceUsage = version >= SemVer(2, 13, 0),
-                    version >= SemVer(2, 19, 0),
+                    wildcardSsh = version >= SemVer(2, 19, 0),
+                    buildReason = version >= SemVer(2, 25, 0),
                 )
             }
         }

--- a/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/CoderRestClient.kt
@@ -241,6 +241,7 @@ open class CoderRestClient(
     /**
      * @throws [APIResponseException].
      */
+    @Deprecated(message = "This operation needs to be delegated to the CLI")
     suspend fun startWorkspace(workspace: Workspace): WorkspaceBuild {
         val buildRequest = CreateWorkspaceBuildRequest(
             null,

--- a/src/main/kotlin/com/coder/toolbox/sdk/v2/models/WorkspaceBuild.kt
+++ b/src/main/kotlin/com/coder/toolbox/sdk/v2/models/WorkspaceBuild.kt
@@ -10,20 +10,41 @@ import java.util.UUID
  */
 @JsonClass(generateAdapter = true)
 data class WorkspaceBuild(
-    @Json(name = "template_version_id") val templateVersionID: UUID,
-    @Json(name = "resources") val resources: List<WorkspaceResource>,
-    @Json(name = "status") val status: WorkspaceStatus,
+    @property:Json(name = "template_version_id") val templateVersionID: UUID,
+    @property:Json(name = "resources") val resources: List<WorkspaceResource>,
+    @property:Json(name = "status") val status: WorkspaceStatus,
 )
 
 enum class WorkspaceStatus {
-    @Json(name = "pending") PENDING,
-    @Json(name = "starting") STARTING,
-    @Json(name = "running") RUNNING,
-    @Json(name = "stopping") STOPPING,
-    @Json(name = "stopped") STOPPED,
-    @Json(name = "failed") FAILED,
-    @Json(name = "canceling") CANCELING,
-    @Json(name = "canceled") CANCELED,
-    @Json(name = "deleting") DELETING,
-    @Json(name = "deleted") DELETED,
+    @Json(name = "pending")
+    PENDING,
+
+    @Json(name = "starting")
+    STARTING,
+
+    @Json(name = "running")
+    RUNNING,
+
+    @Json(name = "stopping")
+    STOPPING,
+
+    @Json(name = "stopped")
+    STOPPED,
+
+    @Json(name = "failed")
+    FAILED,
+
+    @Json(name = "canceling")
+    CANCELING,
+
+    @Json(name = "canceled")
+    CANCELED,
+
+    @Json(name = "deleting")
+    DELETING,
+
+    @Json(name = "deleted")
+    DELETED;
+
+    fun isNotStarted(): Boolean = this != STARTING && this != RUNNING
 }

--- a/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
+++ b/src/main/kotlin/com/coder/toolbox/util/CoderProtocolHandler.kt
@@ -84,7 +84,7 @@ open class CoderProtocolHandler(
             }
             reInitialize(restClient, cli)
             context.envPageManager.showPluginEnvironmentsPage()
-            if (!prepareWorkspace(workspace, restClient, workspaceName, deploymentURL)) return
+            if (!prepareWorkspace(workspace, restClient, cli, workspaceName, deploymentURL)) return
             // we resolve the agent after the workspace is started otherwise we can get misleading
             // errors like: no agent available while workspace is starting or stopping
             // we also need to retrieve the workspace again to have the latest resources (ex: agent)
@@ -180,6 +180,7 @@ open class CoderProtocolHandler(
     private suspend fun prepareWorkspace(
         workspace: Workspace,
         restClient: CoderRestClient,
+        cli: CoderCLIManager,
         workspaceName: String,
         deploymentURL: String
     ): Boolean {
@@ -207,7 +208,7 @@ open class CoderProtocolHandler(
                     if (workspace.outdated) {
                         restClient.updateWorkspace(workspace)
                     } else {
-                        restClient.startWorkspace(workspace)
+                        cli.startWorkspace(workspace.ownerName, workspace.name)
                     }
                 } catch (e: Exception) {
                     context.logAndShowError(

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -976,8 +976,24 @@ internal class CoderCLIManagerTest {
         val tests =
             listOf(
                 Pair("2.5.0", Features(true)),
-                Pair("2.13.0", Features(true, true)),
-                Pair("4.9.0", Features(true, true, true)),
+                Pair("2.13.0", Features(disableAutostart = true, reportWorkspaceUsage = true)),
+                Pair(
+                    "2.25.0",
+                    Features(
+                        disableAutostart = true,
+                        reportWorkspaceUsage = true,
+                        wildcardSsh = true,
+                        buildReason = true
+                    )
+                ),
+                Pair(
+                    "4.9.0", Features(
+                        disableAutostart = true,
+                        reportWorkspaceUsage = true,
+                        wildcardSsh = true,
+                        buildReason = true
+                    )
+                ),
                 Pair("2.4.9", Features(false)),
                 Pair("1.0.1", Features(false)),
             )


### PR DESCRIPTION
Netflix uses custom MFA that requires CLI middleware to handle auth flow. The custom CLI implementation on their side intercepts 403 responses from the REST API, handles the MFA challenge, and retries the rest call again. The MFA challenge is handled only by the `start` and `ssh` actions. The remaining actions can go directly to the REST endpoints because of the custom header command that provides MFA tokens to the http calls.

Both Gateway and VS Code extension delegate the start logic to the CLI, but not Toolbox which caused issues for the customer. This PR ports some of the work from Gateway in Coder Toolbox.