### PR TITLE
fix: enable verbose for the proxy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- the proxy command now always logs in verbose mode when the log directory is enabled
+
 ## 0.8.1 - 2025-12-11
 
 ### Changed

--- a/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/cli/CoderCLIManager.kt
@@ -384,8 +384,7 @@ class CoderCLIManager(
                 "--network-info-dir ${escape(context.settingsStore.networkInfoDir)}"
             )
         val proxyArgs = baseArgs + listOfNotNull(
-            context.settingsStore.sshLogDirectory?.takeIf { it.isNotBlank() }?.let { "--log-dir" },
-            context.settingsStore.sshLogDirectory?.takeIf { it.isNotBlank() }?.let { escape(it) },
+            context.settingsStore.sshLogDirectory?.takeIf { it.isNotBlank() }?.let { "--log-dir ${escape(it)} -v" },
             if (feats.reportWorkspaceUsage) "--usage-app=jetbrains" else null,
         )
         val extraConfig = context.settingsStore.sshConfigOptions

--- a/src/test/resources/fixtures/outputs/log-dir.conf
+++ b/src/test/resources/fixtures/outputs/log-dir.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --log-dir /tmp/coder-toolbox/test.coder.invalid/logs --usage-app=jetbrains owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --log-dir /tmp/coder-toolbox/test.coder.invalid/logs -v --usage-app=jetbrains owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null


### PR DESCRIPTION
When log dir setting is enabled we need to also enable verbose mode otherwise the proxy command will not log anything relevant.

- resolves #240