### PR TITLE
fix: render account name immediately after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - mTLS certificate refresh and http request retrying logic
+- account name is now rendered immediately after login
 
 ## 0.8.2 - 2026-01-06
 


### PR DESCRIPTION
In the top right corner of the main page there is a dropdown rendering the username. In the recent versions of Toolbox the dropdown is built before we initialize the http client and resolve the username.

The fix consists on building the dropdown field with empty data and then push the username label as soon as the user connected.