### PR TITLE
fix: misleading error after OAuth is disabled

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -438,7 +438,7 @@ class CoderRemoteProvider(
         if (!context.settingsStore.preferOAuth2IfAvailable) {
             context.logAndShowError(
                 FAILED_TO_HANDLE_OAUTH2_TITLE,
-                "OAuth authentication is no longer preferred or enabled for Coder Toolbox. Please use API tokens instead."
+                "OAuth based authentication is not enabled for Coder plugin in Toolbox. Please enable it in plugin settings or use the API token instead."
             )
             return
         }

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -434,7 +434,14 @@ class CoderRemoteProvider(
             FAILED_TO_HANDLE_OAUTH2_TITLE,
             "OAuth2 server did not respond back with an access token"
         )
-
+        // before going forward we check to make sure OAuth is not disabled in the meantime
+        if (!context.settingsStore.preferOAuth2IfAvailable) {
+            context.logAndShowError(
+                FAILED_TO_HANDLE_OAUTH2_TITLE,
+                "OAuth authentication is no longer preferred or enabled for Coder Toolbox. Please use API tokens instead."
+            )
+            return
+        }
         exchangeOAuthCodeForToken(code, CoderSetupWizardContext.oauthSession!!)
     }
 


### PR DESCRIPTION
In the edge case where the user disables the OAuth authentication while the authorization page is opened on the server, and then user hits Allow, the URI executes. But the plugin tries to initialize the rest api client and CLI without checking that OAuth is no longer allowed. This raises a misleading error.

The fix is somewhat simple, before exchanging the authorization code with an acces token we check if OAuth is still enabled and if not we fail fast with a proper error message.
For cases where Cancel is selected by the user on the authorization page we allow the flow to go as usual in Toolbox.

- raised https://github.com/coder/coder/issues/24912 while investigating this issue
- resolves https://linear.app/codercom/issue/DEVEX-222