### PR TITLE
fix: account dropdown not refreshed when switching users on the same …

### DIFF
--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -531,6 +531,8 @@ class CoderRemoteProvider(
         this.client = newRestClient
         this.cli = newCli
         lastEnvironments.forEach { it.updateClientAndCli(newRestClient, newCli) }
+        accountDropdownField.labelState.update { context.i18n.pnotr(newRestClient.me.username) }
+        accountDropdownField.visibility.update { true }
         coderHeaderPage.resetFilter()
         context.cs.launch(CoroutineName("Load Templates")) { coderHeaderPage.reloadTemplates() }
         pollJob = poll(newRestClient, newCli)


### PR DESCRIPTION
…deployment via URI

When two Coder URIs targeting the same deployment URL but different users are opened in sequence, the account dropdown in the plugin header would still show the username from the first session instead of updating to reflect the newly authenticated user.

This happened because the same-URL URI handling path calls refreshSession() directly, bypassing the onConnect callback that normally updates the account dropdown label after a successful connection. While refreshSession() correctly replaced the REST client and CLI instances with ones authenticated as the new user, it never propagated that change to the UI.

The fix updates refreshSession() to also refresh the account dropdown label and visibility immediately after the new client is initialized, keeping the UI consistent with the active session.

- resolves DEVEX-372
- resolves DEVEX-374