### PR TITLE
Use catalog for buildSrc dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.22.1")
-    implementation("org.jetbrains.intellij.plugins:structure-toolbox:3.331")
-    implementation("org.jetbrains.intellij:plugin-repository-rest-client:2.0.51")
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.plugin.structure)
+    implementation(libs.marketplace.client)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ plugin-structure = "3.331"
 mockk = "1.14.11"
 detekt = "1.23.8"
 bouncycastle = "1.84"
+jackson = "2.22.1"
 
 [libraries]
 toolbox-core-api = { module = "com.jetbrains.toolbox:core-api", version.ref = "toolbox-plugin-api" }
@@ -38,6 +39,7 @@ mokk = { module = "io.mockk:mockk", version.ref = "mockk" }
 marketplace-client = { module = "org.jetbrains.intellij:plugin-repository-rest-client", version.ref = "marketplace-client" }
 bouncycastle-bcpg = { module = "org.bouncycastle:bcpg-jdk18on", version.ref = "bouncycastle" }
 bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 
 [bundles]
 serialization = ["serialization-core", "serialization-json", "serialization-json-okio"]


### PR DESCRIPTION
Move `buildSrc` dependencies into the shared Gradle version catalog and configure it to use that catalog. `buildSrc` is Gradle’s special folder for build-related code and custom tasks—here, it supports building, packaging, installing, and publishing the Toolbox plugin—so centralizing its dependency versions keeps them consistent and easier to maintain.