### PR TITLE
Improve Gradle build logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.github.jk1.license.filter.ExcludeTransitiveDependenciesFilter
 import com.github.jk1.license.render.JsonReportRenderer
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlin)
@@ -18,6 +17,10 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://packages.jetbrains.team/maven/p/tbx/toolbox-api")
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 jvmWrapper {
@@ -68,10 +71,6 @@ licenseReport {
     filters = arrayOf(ExcludeTransitiveDependenciesFilter())
     // jq script to convert to our format:
     // `jq '[.dependencies[] | {name: .moduleName, version: .moduleVersion, url: .moduleUrl, license: .moduleLicense, licenseUrl: .moduleLicenseUrl}]' < build/reports/dependency-license/dependencies.json > src/main/resources/dependencies.json`
-}
-
-tasks.compileKotlin {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 }
 
 tasks.test {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     `kotlin-dsl`
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     mavenCentral()
     maven("https://packages.jetbrains.team/maven/p/tbx/toolbox-api")

--- a/buildSrc/src/main/kotlin/InstallToolboxPluginTask.kt
+++ b/buildSrc/src/main/kotlin/InstallToolboxPluginTask.kt
@@ -5,7 +5,9 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Sync
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Writes to a user-managed Toolbox installation (i.e. a location not managed by Gradle) that may have changed since a prior run")
 abstract class InstallToolboxPluginTask : Sync() {
 
     @get:InputFiles

--- a/buildSrc/src/main/kotlin/PublishToolboxPluginTask.kt
+++ b/buildSrc/src/main/kotlin/PublishToolboxPluginTask.kt
@@ -4,7 +4,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Uploads to the Marketplace, an external side effect that Gradle cannot reproduce from cache")
 abstract class PublishToolboxPluginTask : DefaultTask() {
 
     @get:Input

--- a/buildSrc/src/main/kotlin/toolbox-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolbox-convention.gradle.kts
@@ -14,7 +14,7 @@ val extensionJson by tasks.registering(GenerateExtensionJsonTask::class) {
 tasks.named<Jar>("jar") {
     archiveBaseName.set(project.group.toString())
     dependsOn(extensionJson)
-    from(extensionJson.get().outputs)
+    from(extensionJson.flatMap { it.outputFile })
 }
 
 val filteredDependencies = configurations.named("compileClasspath").map {


### PR DESCRIPTION
Configure JDK 21 toolchains for the plugin and build logic so local and CI builds use the same compiler. Disable caching for install and publish tasks because they modify the local Toolbox directory or upload externally. Keep extension JSON wiring lazy to avoid eagerly realizing its task during configuration.

Without these changes, builds can vary with the installed JDK, external side effects may be treated as cacheable work, and Gradle does unnecessary configuration work.