### PR TITLE
Restore flat Marketplace plugin ZIP layout

### DIFF
--- a/buildSrc/src/main/kotlin/ToolboxPluginZipTask.kt
+++ b/buildSrc/src/main/kotlin/ToolboxPluginZipTask.kt
@@ -1,8 +1,6 @@
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -25,24 +23,13 @@ abstract class ToolboxPluginZipTask : Zip() {
     @get:InputDirectory
     abstract val resourcesDir: DirectoryProperty
 
-    @get:Input
-    abstract val pluginDirectory: Property<String>
-
     init {
         from(extensionJsonFiles)
-        from(dependenciesFile) {
-            into(pluginDirectory)
-        }
+        from(dependenciesFile)
         from(resourcesDir) {
             include("icon.svg", "pluginIcon.svg")
-            into(pluginDirectory)
         }
-        from(jarFiles) {
-            into(pluginDirectory.map { "$it/lib" })
-        }
-        from(runtimeDependencies) {
-            into(pluginDirectory.map { "$it/lib" })
-        }
-        pluginDirectory.convention("")
+        from(jarFiles)
+        from(runtimeDependencies)
     }
 }

--- a/buildSrc/src/main/kotlin/ValidateToolboxPluginZipTask.kt
+++ b/buildSrc/src/main/kotlin/ValidateToolboxPluginZipTask.kt
@@ -2,7 +2,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -14,9 +13,6 @@ abstract class ValidateToolboxPluginZipTask : DefaultTask() {
     @get:InputFile
     abstract val pluginFile: RegularFileProperty
 
-    @get:Input
-    abstract val extensionId: Property<String>
-
     @get:InputFiles
     abstract val expectedLibraries: ConfigurableFileCollection
 
@@ -25,19 +21,15 @@ abstract class ValidateToolboxPluginZipTask : DefaultTask() {
 
     @TaskAction
     fun validate() {
-        val pluginDirectory = "${extensionId.get()}/"
         val expectedResources = setOf("dependencies.json", "icon.svg", "pluginIcon.svg")
 
         ZipFile(pluginFile.get().asFile).use { zip ->
             val entries = zip.entries().asSequence().filterNot { it.isDirectory }.map { it.name }.toSet()
             val missingEntries = buildSet {
                 if ("extension.json" !in entries) add("extension.json")
-                expectedResources
-                    .map { "$pluginDirectory$it" }
-                    .filterNot(entries::contains)
-                    .forEach(::add)
+                expectedResources.filterNot(entries::contains).forEach(::add)
                 expectedLibraries.files
-                    .map { "$pluginDirectory" + "lib/${it.name}" }
+                    .map { it.name }
                     .filterNot(entries::contains)
                     .forEach(::add)
             }
@@ -45,22 +37,20 @@ abstract class ValidateToolboxPluginZipTask : DefaultTask() {
                 "Plugin ZIP is missing required entries: ${missingEntries.sorted().joinToString()}"
             }
 
-            val rootEntries = entries.filterNot { '/' in it }.toSet()
-            check(rootEntries == setOf("extension.json")) {
-                "Plugin ZIP must contain only extension.json at its root; found: ${rootEntries.sorted().joinToString()}"
-            }
-
-            val misplacedLibraries = entries.filter { it.endsWith(".jar") && !it.startsWith("${pluginDirectory}lib/") }
-            check(misplacedLibraries.isEmpty()) {
-                "Plugin ZIP libraries must be under ${pluginDirectory}lib: ${misplacedLibraries.sorted().joinToString()}"
+            val nestedEntries = entries.filter { '/' in it }
+            check(nestedEntries.isEmpty()) {
+                "Plugin ZIP must use the flat Toolbox plugin layout; found nested entries: ${
+                    nestedEntries.sorted().joinToString()
+                }"
             }
 
             val bundledToolboxDependencies = entries.filter { entry ->
-                entry.startsWith("${pluginDirectory}lib/") &&
-                    toolboxProvidedDependencyNames.get().any(entry::contains)
+                entry.endsWith(".jar") && toolboxProvidedDependencyNames.get().any(entry::contains)
             }
             check(bundledToolboxDependencies.isEmpty()) {
-                "Plugin ZIP must not bundle Toolbox-provided dependencies: ${bundledToolboxDependencies.sorted().joinToString()}"
+                "Plugin ZIP must not bundle Toolbox-provided dependencies: ${
+                    bundledToolboxDependencies.sorted().joinToString()
+                }"
             }
         }
     }

--- a/buildSrc/src/main/kotlin/toolbox-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolbox-convention.gradle.kts
@@ -45,14 +45,12 @@ val packagePlugin by tasks.registering(ToolboxPluginZipTask::class) {
     dependenciesFile.set(generatedDependenciesJson.flatMap { it.outputFile })
     runtimeDependencies.from(filteredDependencies)
     resourcesDir.set(layout.projectDirectory.dir("src/main/resources"))
-    pluginDirectory.set(project.group.toString())
-    archiveBaseName.set(project.group.toString())
+    archiveBaseName.set("coder-toolbox")
 }
 
 val validatePluginZip by tasks.registering(ValidateToolboxPluginZipTask::class) {
     dependsOn(packagePlugin)
     pluginFile.set(packagePlugin.flatMap { it.archiveFile })
-    extensionId.set(project.group.toString())
     expectedLibraries.from(tasks.named<Jar>("jar"))
     expectedLibraries.from(filteredDependencies)
     toolboxProvidedDependencyNames.set(TOOLBOX_PROVIDED_DEPENDENCIES)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.9.2-alpha1
+version=0.9.2-alpha2
 group=com.coder.toolbox
 name=coder-toolbox


### PR DESCRIPTION
Package plugin files at the archive root again but unlike the previous structore we renamed the release ZIP to coder-toolbox-<version>.zip. Toolbox does not recommend the name of the zip to be the plugin ID.