### PR TITLE
fix: keep workspace polling alive when SSH config updates fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- keep workspace polling alive when SSH config updates fail
+
 ## 0.9.2-alpha2 - 2026-07-24
 
 ### Changed

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteProvider.kt
@@ -62,6 +62,7 @@ import com.jetbrains.toolbox.api.ui.components.AccountDropdownField as dropDownF
 private val POLL_INTERVAL = 5.seconds
 private const val CAN_T_HANDLE_URI_TITLE = "Can't handle URI"
 private const val FAILED_TO_HANDLE_OAUTH2_TITLE = "Failed to handle OAuth2 request"
+private const val SSH_CONFIGURATION_WARNING_TITLE = "SSH configuration could not be updated"
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CoderRemoteProvider(
@@ -70,6 +71,7 @@ class CoderRemoteProvider(
     // Current polling job.
     private var pollJob: Job? = null
     internal val lastEnvironments = mutableListOf<CoderRemoteEnvironment>()
+    private var isSshConfigurationWarningShown = false
 
     private val sshConfigTrigger = Channel<Boolean>(Channel.CONFLATED)
     private val workspaceRefreshTrigger = Channel<Boolean>(Channel.CONFLATED)
@@ -120,7 +122,7 @@ class CoderRemoteProvider(
      * workspace is added, reconfigure SSH using the provided cli (including the
      * first time).
      */
-    private fun poll(client: CoderRestClient, cli: CoderCLIManager): Job =
+    internal fun poll(client: CoderRestClient, cli: CoderCLIManager): Job =
         context.cs.launch(CoroutineName("Workspace Poller")) {
             var lastPollTime = TimeSource.Monotonic.markNow()
             while (isActive) {
@@ -140,7 +142,7 @@ class CoderRemoteProvider(
                     // Reconfigure if environments changed.
                     if (lastEnvironments.size != resolvedEnvironments.size || lastEnvironments != resolvedEnvironments) {
                         context.logger.info("Workspaces have changed, reconfiguring CLI: $resolvedEnvironments")
-                        cli.configSsh(resolvedEnvironments.mapNotNull { it.toWorkspaceAgentPairOrNull() }.toSet())
+                        configureSsh(cli, resolvedEnvironments)
                     }
 
                     environments.update {
@@ -185,7 +187,7 @@ class CoderRemoteProvider(
                     sshConfigTrigger.onReceive { shouldTrigger ->
                         if (shouldTrigger) {
                             context.logger.debug("workspace poller waked up because it should reconfigure the ssh configurations")
-                            cli.configSsh(lastEnvironments.mapNotNull { it.toWorkspaceAgentPairOrNull() }.toSet())
+                            configureSsh(cli, lastEnvironments)
                         }
                     }
                     workspaceRefreshTrigger.onReceive { shouldTrigger ->
@@ -202,6 +204,31 @@ class CoderRemoteProvider(
                 lastPollTime = TimeSource.Monotonic.markNow()
             }
         }
+
+    /**
+     * Keep SSH configuration failures separate from workspace discovery.  SSH
+     * configuration is necessary to connect, but a read-only or malformed SSH
+     * config must not prevent Toolbox from showing the workspaces it resolved.
+     */
+    private fun configureSsh(cli: CoderCLIManager, resolvedEnvironments: List<CoderRemoteEnvironment>) {
+        try {
+            cli.configSsh(resolvedEnvironments.mapNotNull { it.toWorkspaceAgentPairOrNull() }.toSet())
+            isSshConfigurationWarningShown = false
+        } catch (ex: Exception) {
+            if (!isSshConfigurationWarningShown) {
+                isSshConfigurationWarningShown = true
+                val reason = ex.message?.takeIf { it.isNotBlank() } ?: ex.javaClass.simpleName
+                context.logAndShowWarning(
+                    SSH_CONFIGURATION_WARNING_TITLE,
+                    "Workspaces remain available, but SSH connections are unavailable: $reason. " +
+                            "Update ${context.settingsStore.sshConfigPath} and try again.",
+                    ex,
+                )
+            } else {
+                context.logger.warn(ex, "Failed to update SSH configuration at ${context.settingsStore.sshConfigPath}")
+            }
+        }
+    }
 
     /**
      * Resolves workspace agents into remote environments.
@@ -294,6 +321,7 @@ class CoderRemoteProvider(
         cli = null
         lastEnvironments.forEach { it.dispose() }
         lastEnvironments.clear()
+        isSshConfigurationWarningShown = false
         environments.value = LoadableState.Value(emptyList())
         isInitialized.update { false }
         accountDropdownField.visibility.update { false }

--- a/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderToolboxContext.kt
@@ -69,6 +69,11 @@ data class CoderToolboxContext(
         showInfoPopup(title, warning)
     }
 
+    fun logAndShowWarning(title: String, warning: String, exception: Exception) {
+        logger.warn(exception, warning)
+        showInfoPopup(title, warning)
+    }
+
     fun logAndShowInfo(title: String, info: String) {
         logger.info(info)
         showInfoPopup(title, info)

--- a/src/test/kotlin/com/coder/toolbox/CoderRemoteProviderTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/CoderRemoteProviderTest.kt
@@ -14,14 +14,21 @@ import com.coder.toolbox.store.CoderSettingsStore
 import com.coder.toolbox.views.CoderSetupWizardPage
 import com.coder.toolbox.views.state.StoredOAuthSession
 import com.coder.toolbox.views.state.WizardStep
+import com.jetbrains.toolbox.api.core.util.LoadableState
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertTrue
+import java.io.FileNotFoundException
 import java.net.URI
 import java.util.UUID
 import kotlin.test.AfterTest
@@ -64,6 +71,40 @@ class CoderRemoteProviderTest {
         val result = remoteProvider.resolveWorkspaceEnvironments(mockClient, mockCli)
         // then
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `SSH configuration failure does not prevent resolved workspaces from being published`() = runTest {
+        // given
+        every { mockContext.cs } returns CoroutineScope(StandardTestDispatcher(testScheduler))
+        every { mockContext.settingsStore.sshConfigPath } returns "/Users/test/.ssh/config"
+        val agent = mockAgent("agent1")
+        val workspace = mockWorkspace("ws1", WorkspaceStatus.RUNNING, listOf(mockResource(listOf(agent))))
+        coEvery { mockClient.workspaces(any()) } returns listOf(workspace)
+        every { mockCli.configSsh(any(), any()) } throws FileNotFoundException("Permission denied")
+
+        // when
+        val pollJob = remoteProvider.poll(mockClient, mockCli)
+        runCurrent()
+
+        // then
+        val environments = remoteProvider.environments.value
+        when (environments) {
+            is LoadableState.Value -> assertEquals("ws1.agent1", environments.value.single().id)
+            else -> error("Expected resolved workspaces to be published, but got $environments")
+        }
+        val warningText = slot<String>()
+        verify(exactly = 1) {
+            mockContext.logAndShowWarning(
+                "SSH configuration could not be updated",
+                capture(warningText),
+                any(),
+            )
+        }
+        assertTrue(warningText.captured.contains("Permission denied"))
+
+        pollJob.cancel()
     }
 
     @Test


### PR DESCRIPTION
Publish discovered workspaces even when the SSH configuration cannot be updated, and show a warning with the failure reason. SSH setup failures remain logged without repeatedly aborting the polling loop.

- related to [DEVEX-632](https://linear.app/codercom/issue/DEVEX-632)
- related to [#336](https://github.com/coder/coder-jetbrains-toolbox/issues/336)