### PR TITLE
test: skip POSIX shell-injection test on Windows

### DIFF
--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -684,7 +684,10 @@ internal class CoderCLIManagerTest {
                     )
                     .let { conf ->
                         if (it.sshLogDirectory != null) {
-                            conf.replace("/tmp/coder-toolbox/test.coder.invalid/logs", it.sshLogDirectory.toString())
+                            conf.replace(
+                                "/tmp/coder-toolbox/test.coder.invalid/logs",
+                                ProxyCommandBuilder().argument(it.sshLogDirectory.toString()).render(),
+                            )
                         } else {
                             conf
                         }

--- a/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/CoderCLIManagerTest.kt
@@ -682,6 +682,12 @@ internal class CoderCLIManagerTest {
                         "/tmp/coder-toolbox/ssh-network-metrics",
                         ProxyCommandBuilder().argument(networkMetricsPath.toString()).render(),
                     )
+                    .replace(
+                        "/tmp/coder-toolbox/test.coder.invalid/url",
+                        ProxyCommandBuilder()
+                            .argument((it.url ?: URI.create("https://test.coder.invalid").toURL()).toString())
+                            .render(),
+                    )
                     .let { conf ->
                         if (it.sshLogDirectory != null) {
                             conf.replace(

--- a/src/test/kotlin/com/coder/toolbox/cli/ProxyCommandBuilderTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/cli/ProxyCommandBuilderTest.kt
@@ -1,5 +1,6 @@
 package com.coder.toolbox.cli
 
+import com.coder.toolbox.util.IgnoreOnWindows
 import com.coder.toolbox.util.OS
 import java.nio.file.Files
 import kotlin.test.Test
@@ -45,6 +46,7 @@ internal class ProxyCommandBuilderTest {
     }
 
     @Test
+    @IgnoreOnWindows
     fun `rendered POSIX command does not execute command substitutions`() {
         val sentinel = Files.createTempDirectory("proxy-command-test").resolve("executed")
         val payload = "\$(touch${'$'}{IFS}$sentinel)"

--- a/src/test/resources/fixtures/outputs/url.conf
+++ b/src/test/resources/fixtures/outputs/url.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS TOOLBOX test.coder.invalid
 Host coder-jetbrains-toolbox--owner--foo.agent1--test.coder.invalid
-  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url 'https://test.coder.invalid?foo=bar&baz=qux' ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains -- owner/foo.agent1
+  ProxyCommand /tmp/coder-toolbox/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-toolbox/test.coder.invalid/config --url /tmp/coder-toolbox/test.coder.invalid/url ssh --stdio --network-info-dir /tmp/coder-toolbox/ssh-network-metrics --usage-app=jetbrains -- owner/foo.agent1
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null


### PR DESCRIPTION
It shells out to /bin/sh to verify the rendered command is safe against a real POSIX shell, but that path doesn't exist on Windows, causing the test to fail there regardless of correctness.