### PR TITLE
fix: derive deployment target from workspace agent OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- deployment target OS is now derived from the workspace agent's reported OS, falling back to automatic detection when
+  unknown
+
 ## 0.9.2 - 2026-08-06
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.9.2
+version=0.9.3
 group=com.coder.toolbox
 name=coder-toolbox

--- a/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
+++ b/src/main/kotlin/com/coder/toolbox/CoderRemoteEnvironment.kt
@@ -10,6 +10,7 @@ import com.coder.toolbox.sdk.ex.APIResponseException
 import com.coder.toolbox.sdk.v2.models.NetworkMetrics
 import com.coder.toolbox.sdk.v2.models.Workspace
 import com.coder.toolbox.sdk.v2.models.WorkspaceAgent
+import com.coder.toolbox.util.OS
 import com.coder.toolbox.util.waitForFalseWithTimeout
 import com.coder.toolbox.util.withPath
 import com.coder.toolbox.views.Action
@@ -21,7 +22,10 @@ import com.jetbrains.toolbox.api.remoteDev.AfterDisconnectHook
 import com.jetbrains.toolbox.api.remoteDev.BeforeConnectionHook
 import com.jetbrains.toolbox.api.remoteDev.EnvironmentVisibilityState
 import com.jetbrains.toolbox.api.remoteDev.RemoteProviderEnvironment
+import com.jetbrains.toolbox.api.remoteDev.deploy.DeploymentSettings
+import com.jetbrains.toolbox.api.remoteDev.deploy.DeploymentTarget
 import com.jetbrains.toolbox.api.remoteDev.environments.EnvironmentContentsView
+import com.jetbrains.toolbox.api.remoteDev.environments.WithDeploymentSettings
 import com.jetbrains.toolbox.api.remoteDev.states.EnvironmentDescription
 import com.jetbrains.toolbox.api.remoteDev.states.RemoteEnvironmentState
 import com.jetbrains.toolbox.api.ui.actions.ActionDescription
@@ -48,6 +52,13 @@ private val POLL_INTERVAL = 5.seconds
 private fun environmentId(workspace: Workspace, agent: WorkspaceAgent?): String =
     agent?.let { "${workspace.name}.${it.name}" } ?: workspace.name
 
+private fun OS?.toDeploymentTarget(): DeploymentTarget = when (this) {
+    OS.LINUX -> DeploymentTarget.LINUX
+    OS.MAC -> DeploymentTarget.MACOS
+    OS.WINDOWS -> DeploymentTarget.WINDOWS
+    else -> DeploymentTarget.AUTO
+}
+
 /**
  * Represents a workspace, or a workspace and agent combination when an agent is available.
  *
@@ -60,7 +71,8 @@ class CoderRemoteEnvironment(
     private val workspaceRefreshTrigger: Channel<Boolean>,
     private var workspace: Workspace,
     private var agent: WorkspaceAgent?,
-) : RemoteProviderEnvironment(environmentId(workspace, agent)), BeforeConnectionHook, AfterDisconnectHook {
+) : RemoteProviderEnvironment(environmentId(workspace, agent)), BeforeConnectionHook, AfterDisconnectHook,
+    WithDeploymentSettings {
     private var environmentStatus = WorkspaceAndAgentStatus.from(workspace, agent)
 
     override var name: String = environmentId(workspace, agent)
@@ -73,6 +85,13 @@ class CoderRemoteEnvironment(
         MutableStateFlow(EnvironmentDescription.General(context.i18n.pnotr(workspace.templateDisplayName)))
     override val additionalEnvironmentInformation: MutableMap<LocalizableString, String> = mutableMapOf()
     override val actionsList: MutableStateFlow<List<ActionDescription>> = MutableStateFlow(emptyList())
+
+    /**
+     * Derives the deployment target from the agent's reported OS, falling back to
+     * AUTO (automatic remote OS detection) when the agent or its OS is unknown.
+     */
+    override val deploymentSettings: DeploymentSettings
+        get() = DeploymentSettings.Default.copy(deploymentTarget = agent?.operatingSystem.toDeploymentTarget())
 
     private val networkMetricsMarshaller = Moshi.Builder().build().adapter(NetworkMetrics::class.java)
     private val proxyCommandHandle = SshCommandProcessHandle(context)


### PR DESCRIPTION
Overrides WithDeploymentSettings to map the agent's reported operating system to a DeploymentTarget, falling back to AUTO when unknown.

This would "relieve" most of the pressure on Toolbox to determine the remote environment OS before starting to deploy the TBX agent, and of course that leaves less room for error.