### PR TITLE
impl: fall back to CODER_HEADER_COMMAND when the header command setting is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- the header command falls back to the `CODER_HEADER_COMMAND` environment variable when the setting is blank, matching the Coder CLI and the VS Code extension
+
 ## 0.9.3 - 2026-08-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -509,7 +509,8 @@ explicit entry per resolved workspace/agent using
   expansion.
 
 - `Header command` command that outputs additional HTTP headers. Each line of output must be in the format key=value.
-  The environment variable CODER_URL will be available to the command process.
+  The environment variable CODER_URL will be available to the command process. If left blank, the
+  `CODER_HEADER_COMMAND` environment variable is used, if set.
 
 - `lastDeploymentURL` the last Coder deployment URL that Coder Toolbox successfully authenticated to.
 

--- a/README.md
+++ b/README.md
@@ -509,8 +509,7 @@ explicit entry per resolved workspace/agent using
   expansion.
 
 - `Header command` command that outputs additional HTTP headers. Each line of output must be in the format key=value.
-  The environment variable CODER_URL will be available to the command process. If left blank, the
-  `CODER_HEADER_COMMAND` environment variable is used, if set.
+  When this setting is left blank, the `CODER_HEADER_COMMAND` environment variable is used instead, if set.
 
 - `lastDeploymentURL` the last Coder deployment URL that Coder Toolbox successfully authenticated to.
 

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -94,7 +94,9 @@ interface ReadOnlyCoderSettings {
      * An external command that outputs additional HTTP headers added to all
      * requests. The command must output each header as `key=value` on its own
      * line. The following environment variables will be available to the
-     * process: CODER_URL.
+     * process: CODER_URL. Falls back to the CODER_HEADER_COMMAND environment
+     * variable (the same variable the Coder CLI reads) when the setting is
+     * blank.
      */
     val headerCommand: String?
 

--- a/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
+++ b/src/main/kotlin/com/coder/toolbox/settings/ReadOnlyCoderSettings.kt
@@ -93,10 +93,8 @@ interface ReadOnlyCoderSettings {
     /**
      * An external command that outputs additional HTTP headers added to all
      * requests. The command must output each header as `key=value` on its own
-     * line. The following environment variables will be available to the
-     * process: CODER_URL. Falls back to the CODER_HEADER_COMMAND environment
-     * variable (the same variable the Coder CLI reads) when the setting is
-     * blank.
+     * line. When this setting is blank, the CODER_HEADER_COMMAND environment
+     * variable (the same variable the Coder CLI reads) is used instead, if set.
      */
     val headerCommand: String?
 

--- a/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/CoderSettingsStore.kt
@@ -54,7 +54,9 @@ class CoderSettingsStore(
     override val globalDataDirectory: String get() = getDefaultGlobalDataDir().normalize().toString()
     override val globalConfigDir: String get() = getDefaultGlobalConfigDir().normalize().toString()
     override val enableDownloads: Boolean get() = store[ENABLE_DOWNLOADS]?.toBooleanStrictOrNull() ?: true
-    override val headerCommand: String? get() = store[HEADER_COMMAND]
+    override val headerCommand: String?
+        get() = store[HEADER_COMMAND].takeUnless { it.isNullOrEmpty() }
+            ?: env.get(CODER_HEADER_COMMAND).takeUnless { it.isEmpty() }
     override val tls: ReadOnlyTLSSettings
         get() = TLSSettings(
             certPath = store[TLS_CERT_PATH],

--- a/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
+++ b/src/main/kotlin/com/coder/toolbox/store/StoreKeys.kt
@@ -2,6 +2,8 @@ package com.coder.toolbox.store
 
 internal const val CODER_SSH_CONFIG_OPTIONS = "CODER_SSH_CONFIG_OPTIONS"
 
+internal const val CODER_HEADER_COMMAND = "CODER_HEADER_COMMAND"
+
 internal const val LAST_USED_URL = "lastDeploymentURL"
 
 internal const val DEFAULT_URL = "defaultURL"

--- a/src/test/kotlin/com/coder/toolbox/settings/CoderSettingsTest.kt
+++ b/src/test/kotlin/com/coder/toolbox/settings/CoderSettingsTest.kt
@@ -1,5 +1,6 @@
 package com.coder.toolbox.settings
 
+import com.coder.toolbox.store.CODER_HEADER_COMMAND
 import com.coder.toolbox.store.CODER_SSH_CONFIG_OPTIONS
 import com.coder.toolbox.store.CoderSettingsStore
 import com.coder.toolbox.store.DISABLE_AUTOSTART
@@ -234,6 +235,30 @@ internal class CoderSettingsTest {
         expected.resolve("session").toFile().delete()
         got = CoderSettingsStore(pluginTestSettingsStore(), Environment(), logger).readOnly().readConfig(expected)
         assertEquals(Pair("http://test.toolbox.coder.com$expected", null), got)
+    }
+
+    @Test
+    fun testHeaderCommand() {
+        var settings = CoderSettingsStore(
+            pluginTestSettingsStore(HEADER_COMMAND to "header command from state"),
+            Environment(), logger
+        )
+        assertEquals("header command from state", settings.readOnly().headerCommand)
+
+        settings = CoderSettingsStore(
+            pluginTestSettingsStore(),
+            env = Environment(mapOf(CODER_HEADER_COMMAND to "header command from env")),
+            logger
+        )
+        assertEquals("header command from env", settings.readOnly().headerCommand)
+
+        // State has precedence.
+        settings = CoderSettingsStore(
+            pluginTestSettingsStore(HEADER_COMMAND to "header command from state"),
+            env = Environment(mapOf(CODER_HEADER_COMMAND to "header command from env")),
+            logger
+        )
+        assertEquals("header command from state", settings.readOnly().headerCommand)
     }
 
     @Test


### PR DESCRIPTION
Same change as coder/jetbrains-coder#600 for the Toolbox plugin: `CoderSettingsStore.headerCommand` falls back to the `CODER_HEADER_COMMAND` environment variable when the stored setting is empty, matching the Coder CLI and the VS Code extension ([`src/settings/headers.ts`](https://github.com/coder/vscode-coder/blob/main/src/settings/headers.ts)), and following the existing `sshConfigOptions` / `CODER_SSH_CONFIG_OPTIONS` fallback in the same class. An unset variable still yields `null`, so the default is unchanged; an explicitly configured setting still wins. README settings entry and the `ReadOnlyCoderSettings` doc updated.

Test: `CoderSettingsTest.testHeaderCommand` (store / env / precedence), mirroring `testSSHConfigOptions`.
