### PR TITLE
fix: use Toolbox cache for Windows plugin installation via Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or from [Coder's Github Release page](https://github.com/coder/coder-jetbrains-t
 
 The next step is to copy the zip content to one of the following locations, depending on your OS:
 
-* Windows: `%LocalAppData%/JetBrains/Toolbox/plugins/com.coder.toolbox`
+* Windows: `%LocalAppData%/JetBrains/Toolbox/cache/plugins/com.coder.toolbox`
 * macOS: `~/Library/Caches/JetBrains/Toolbox/plugins/com.coder.toolbox`
 * Linux: `~/.local/share/JetBrains/Toolbox/plugins/com.coder.toolbox`
 

--- a/buildSrc/src/main/kotlin/PluginUtils.kt
+++ b/buildSrc/src/main/kotlin/PluginUtils.kt
@@ -8,16 +8,29 @@ import kotlin.io.path.div
  * Resolves the Toolbox plugin install directory for the current OS.
  */
 fun getPluginInstallDir(extensionId: String): Path {
-    val userHome = System.getProperty("user.home").let { Path.of(it) }
-    val pluginsDir = when (OS.current()) {
-        OS.WINDOWS -> System.getenv("LOCALAPPDATA")?.let { Path.of(it) } ?: (userHome / "AppData" / "Local")
-        // currently this is the location that TBA uses on Linux
-        OS.LINUX -> System.getenv("XDG_DATA_HOME")?.let { Path.of(it) } ?: (userHome / ".local" / "share")
-        OS.MAC -> userHome / "Library" / "Caches"
-        else -> error("Unknown os")
-    } / "JetBrains" / "Toolbox" / "plugins"
+    val userHome = Path.of(System.getProperty("user.home"))
+    val toolboxDir = when (OS.current()) {
+        OS.WINDOWS -> {
+            val localAppData = System.getenv("LOCALAPPDATA")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { Path.of(it) }
+                ?: (userHome / "AppData" / "Local")
+            localAppData / "JetBrains" / "Toolbox" / "cache"
+        }
 
-    return pluginsDir / extensionId
+        OS.LINUX -> {
+            val dataHome = System.getenv("XDG_DATA_HOME")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { Path.of(it) }
+                ?: (userHome / ".local" / "share")
+            dataHome / "JetBrains" / "Toolbox"
+        }
+
+        OS.MAC -> userHome / "Library" / "Caches" / "JetBrains" / "Toolbox"
+        else -> error("Unknown os")
+    }
+
+    return toolboxDir / "plugins" / extensionId
 }
 
 /**

--- a/src/main/kotlin/com/coder/toolbox/feed/IdeFeedManager.kt
+++ b/src/main/kotlin/com/coder/toolbox/feed/IdeFeedManager.kt
@@ -23,10 +23,10 @@ import kotlin.jvm.optionals.getOrNull
  * This manager handles fetching IDE information from JetBrains data services,
  * caching the results locally, and supporting offline mode.
  *
- * Cache files are stored in platform-specific locations:
- * - macOS: ~/Library/Application Support/JetBrains/Toolbox/plugins/com.coder.toolbox/
- * - Linux: ~/.local/share/JetBrains/Toolbox/plugins/com.coder.toolbox/
- * - Windows: %LOCALAPPDATA%/JetBrains/Toolbox/plugins/com.coder.toolbox/
+ * Cache files are stored in the Coder Toolbox data directory:
+ * - macOS: ~/Library/Application Support/coder-toolbox/
+ * - Linux: ${XDG_DATA_HOME:-~/.local/share}/coder-toolbox/
+ * - Windows: %LOCALAPPDATA%/coder-toolbox/
  */
 class IdeFeedManager(
     private val context: CoderToolboxContext,


### PR DESCRIPTION
Toolbox 3.7 looks for external plugins inside its Windows cache, but the Gradle task (installPlugin) copied them to a different directory, so Toolbox ignored the installed plugin. Use the platform-specific plugin locations for installation and cleanup, and correct the related documentation while keeping the existing Linux and macOS paths.